### PR TITLE
feat: crc64nvme checksum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
  "clap",
  "crc32c",
  "crc32fast",
+ "crc64fast-nvme",
  "criterion",
  "dyn-clone",
  "envy",

--- a/cloud-checksum/Cargo.toml
+++ b/cloud-checksum/Cargo.toml
@@ -24,6 +24,7 @@ sha1 = "0.10"
 sha2 = "0.10"
 crc32fast = "1"
 crc32c = "0.6"
+crc64fast-nvme = "1"
 
 # Value parsing
 serde = { version = "1", features = ["derive"] }

--- a/cloud-checksum/src/checksum/mod.rs
+++ b/cloud-checksum/src/checksum/mod.rs
@@ -136,12 +136,13 @@ impl From<Ctx> for ChecksumAlgorithm {
         };
 
         match ctx {
+            StandardCtx::CRC64NVME(_, _) => ChecksumAlgorithm::Crc64Nvme,
             StandardCtx::CRC32C(_, _) => ChecksumAlgorithm::Crc32C,
             StandardCtx::CRC32(_, _) => ChecksumAlgorithm::Crc32,
             StandardCtx::SHA1(_) => ChecksumAlgorithm::Sha1,
             StandardCtx::SHA256(_) => ChecksumAlgorithm::Sha256,
             // By default, set some algorithm if the context doesn't line up.
-            _ => ChecksumAlgorithm::Crc32,
+            _ => ChecksumAlgorithm::Crc64Nvme,
         }
     }
 }

--- a/cloud-checksum/src/checksum/standard.rs
+++ b/cloud-checksum/src/checksum/standard.rs
@@ -69,7 +69,7 @@ impl Hash for StandardCtx {
 
 impl Default for StandardCtx {
     fn default() -> Self {
-        Self::crc32()
+        Self::crc64nvme()
     }
 }
 
@@ -89,6 +89,7 @@ impl FromStr for StandardCtx {
             Checksum::SHA256 => Self::sha256(),
             Checksum::CRC32 => Self::crc32(),
             Checksum::CRC32C => Self::crc32c(),
+            Checksum::CRC64NVME => Self::crc64nvme(),
             _ => return Err(ParseError("unsupported checksum algorithm".to_string())),
         };
         Ok(ctx)
@@ -171,6 +172,7 @@ impl StandardCtx {
             let ctx = match Checksum::from_str(s)? {
                 Checksum::CRC32 => Self::crc32().with_endianness(Endianness::LittleEndian),
                 Checksum::CRC32C => Self::crc32c().with_endianness(Endianness::LittleEndian),
+                Checksum::CRC64NVME => Self::crc64nvme().with_endianness(Endianness::LittleEndian),
                 _ => return Err(ParseError("invalid suffix -le for checksum".to_string())),
             };
             Ok(Some(ctx))
@@ -178,6 +180,7 @@ impl StandardCtx {
             let ctx = match Checksum::from_str(s)? {
                 Checksum::CRC32 => Self::crc32(),
                 Checksum::CRC32C => Self::crc32c(),
+                Checksum::CRC64NVME => Self::crc64nvme(),
                 _ => return Err(ParseError("invalid suffix -be for checksum".to_string())),
             };
             Ok(Some(ctx))
@@ -191,6 +194,7 @@ impl StandardCtx {
         match self {
             Self::CRC32(ctx, _) => Self::CRC32(ctx, endianness),
             Self::CRC32C(ctx, _) => Self::CRC32C(ctx, endianness),
+            Self::CRC64NVME(ctx, _) => Self::CRC64NVME(ctx, endianness),
             checksum => checksum,
         }
     }
@@ -259,9 +263,9 @@ impl StandardCtx {
     /// Extract the endianness if this is a CRC variant.
     pub fn endianness(&self) -> Option<Endianness> {
         match self {
-            StandardCtx::CRC32(_, endianness) | StandardCtx::CRC32C(_, endianness) => {
-                Some(*endianness)
-            }
+            StandardCtx::CRC32(_, endianness)
+            | StandardCtx::CRC32C(_, endianness)
+            | StandardCtx::CRC64NVME(_, endianness) => Some(*endianness),
             _ => None,
         }
     }

--- a/cloud-checksum/src/io/copy/aws.rs
+++ b/cloud-checksum/src/io/copy/aws.rs
@@ -567,7 +567,6 @@ impl S3 {
                 .body(ByteStream::from(buf))
                 .send()
                 .await?;
-
             Ok((part, part_number, upload_id).into())
         } else {
             self.complete_multipart_upload(

--- a/cloud-checksum/src/lib.rs
+++ b/cloud-checksum/src/lib.rs
@@ -255,6 +255,8 @@ pub enum Checksum {
     CRC32,
     /// Calculate a CRC32C.
     CRC32C,
+    /// Calculate a CRC64NVME.
+    CRC64NVME,
     /// Calculate the QuickXor checksum.
     QuickXor,
 }

--- a/cloud-checksum/src/task/check.rs
+++ b/cloud-checksum/src/task/check.rs
@@ -384,17 +384,17 @@ pub(crate) mod test {
                 SumsFile::new(
                     Some(TEST_FILE_SIZE),
                     BTreeMap::from_iter(vec![
-                        ("md5".parse()?, Checksum::new("123".to_string()),),
-                        ("sha1".parse()?, Checksum::new("456".to_string()),),
-                        ("sha256".parse()?, Checksum::new("789".to_string()),)
+                        ("sha256".parse()?, Checksum::new("abc".to_string()),),
+                        ("crc32".parse()?, Checksum::new("efg".to_string()),),
+                        ("crc32c".parse()?, Checksum::new("hij".to_string()),)
                     ])
                 ),
                 SumsFile::new(
                     Some(TEST_FILE_SIZE),
                     BTreeMap::from_iter(vec![
-                        ("sha256".parse()?, Checksum::new("abc".to_string()),),
-                        ("crc32".parse()?, Checksum::new("efg".to_string()),),
-                        ("crc32c".parse()?, Checksum::new("hij".to_string()),)
+                        ("md5".parse()?, Checksum::new("123".to_string()),),
+                        ("sha1".parse()?, Checksum::new("456".to_string()),),
+                        ("sha256".parse()?, Checksum::new("789".to_string()),)
                     ])
                 )
             ]
@@ -422,18 +422,18 @@ pub(crate) mod test {
                 SumsFile::new(
                     Some(TEST_FILE_SIZE),
                     BTreeMap::from_iter(vec![
-                        ("md5".parse()?, Default::default(),),
-                        ("sha1".parse()?, Default::default(),),
-                        ("sha256".parse()?, Default::default(),)
+                        ("crc32".parse()?, Default::default(),),
+                        ("crc32c".parse()?, Default::default(),)
                     ])
                 ),
                 SumsFile::new(
                     Some(TEST_FILE_SIZE),
                     BTreeMap::from_iter(vec![
-                        ("crc32".parse()?, Default::default(),),
-                        ("crc32c".parse()?, Default::default(),)
+                        ("md5".parse()?, Default::default(),),
+                        ("sha1".parse()?, Default::default(),),
+                        ("sha256".parse()?, Default::default(),)
                     ])
-                )
+                ),
             ]
         );
 

--- a/cloud-checksum/src/task/copy.rs
+++ b/cloud-checksum/src/task/copy.rs
@@ -503,17 +503,15 @@ impl CopyTask {
         }
 
         // Complete the upload
-        download_fn(
-            MultiPartOptions {
-                part_number: None,
-                start,
-                end,
-                upload_id: upload_id.clone(),
-                parts: parts.clone(),
-            },
-            self.state.clone(),
-        )
-        .await?;
+        let options = MultiPartOptions {
+            part_number: None,
+            start,
+            end,
+            upload_id: upload_id.clone(),
+            parts: parts.clone(),
+        };
+        let result = download_fn(options.clone(), self.state.clone()).await?;
+        upload_fn(result, options, self.state.clone()).await?;
 
         Ok(self.state.size())
     }

--- a/cloud-checksum/src/task/generate.rs
+++ b/cloud-checksum/src/task/generate.rs
@@ -389,8 +389,8 @@ pub(crate) mod test {
         assert_eq!(
             result,
             vec![SumCtxPair::new(
-                files.first().unwrap().to_string(),
-                Ctx::Regular(StandardCtx::crc32c())
+                files[2].to_string(),
+                Ctx::Regular(StandardCtx::sha256())
             )]
             .into()
         );

--- a/cloud-checksum/tests/copy.rs
+++ b/cloud-checksum/tests/copy.rs
@@ -201,7 +201,7 @@ fn assert_head_multipart(head: HeadObjectOutput) {
         head.e_tag,
         Some("\"ec1e29805585d04a93eb8cf464b68c43-2\"".to_string())
     );
-    assert_eq!(head.checksum_crc32, Some("H/gGmw==-2".to_string()));
+    assert_eq!(head.checksum_crc64_nvme, Some("yM/EwMxFxsE=".to_string()));
 }
 
 fn assert_head_single_part(head: HeadObjectOutput) {
@@ -209,7 +209,7 @@ fn assert_head_single_part(head: HeadObjectOutput) {
         head.e_tag,
         Some("\"617808065bb1a8be2755f9be0c0ac769\"".to_string())
     );
-    assert_eq!(head.checksum_crc32, Some("URA4jQ==".to_string()));
+    assert_eq!(head.checksum_crc64_nvme, Some("yM/EwMxFxsE=".to_string()));
 }
 
 async fn execute_command(commands: &[&str]) {


### PR DESCRIPTION
Closes #23

### Changes
* Adds crc64nvme checksum support from AWS metadata and generating it from cloud-checksum. This is now the default "preferred" checksum if nothing else was found/specified.
    * I didn't notice any issues from AWS or from the `crc64fast-nvme` with regards to endianness: https://github.com/umccr/cloud-checksum/issues/23#issuecomment-2705246521. Either way, this crate gets the raw bytes of any checksum first and then formats the endianness depending on the settings.
    
### Bug fix
* Avoid using total_parts and checksum_type directly from AWS when getting metadata sums, as the multipart upload status is not always the same as the checksum type.
    * E.g. MD5 is always composite if uploaded using multipart.
    * The additional checksums can be either composite or full object sums depending on the type and options set: https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#ChecksumTypes
    * Instead, parse the type of checksum from the suffix, e.g. ending with "-<n>" or not.
* Add missing `upload_fn` to the copy command.
