### PR TITLE
feat: s3 compatible storage options

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,14 @@ The endpoint URL can also be set for S3-compatible endpoint tests:
 COPYRITE_TEST_BUCKET_URI="s3://bucket/prefix" COPYRITE_TEST_ENDPOINT_URL="https://storage.googleapis.com" cargo test --all-features -- --ignored
 ```
 
+This can also source credentials from a secret, and set compatibility options. The full test environment variables are:
+
+| Variable                      | Description                                                                                                  |
+|-------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `COPYRITE_TEST_BUCKET_URI`    | The S3 bucket and prefix to use.                                                                             |
+| `COPYRITE_TEST_ENDPOINT_URL`  | The S3 endpoint URL.                                                                                         |
+| `COPYRITE_TEST_SECRET`        | The AWS Secrets Manager secret name or ARN, this will also set the credential provider type to `aws-secret`. |
+| `COPYRITE_TEST_REGION`        | The AWS region.                                                                                              |
+| `COPYRITE_TEST_S3_COMPATIBLE` | Set to `true` to enable S3-compatibility.                                                                    |
+
 [sums]: docs/ARCHITECTURE.md#the-sums-file

--- a/copyrite/src/checksum/file.rs
+++ b/copyrite/src/checksum/file.rs
@@ -4,6 +4,7 @@
 use crate::checksum::Ctx;
 use crate::error::Error::SumsFileError;
 use crate::error::{Error, Result};
+use crate::io::S3Client;
 use crate::io::sums::{ObjectSums, ObjectSumsBuilder};
 use serde::{Deserialize, Serialize};
 use serde_json::{from_slice, to_string};
@@ -26,10 +27,10 @@ pub struct State {
 
 impl State {
     /// Build from a name.
-    pub async fn try_from(name: String, no_get_object_attributes: bool) -> Result<Self> {
+    pub async fn try_from(name: String, client: Option<S3Client>) -> Result<Self> {
         Ok(Self {
             object_sums: ObjectSumsBuilder::default()
-                .with_no_get_object_attributes(no_get_object_attributes)
+                .set_client(client)
                 .build(SumsFile::format_target_file(&name))
                 .await?,
             name,

--- a/copyrite/src/checksum/file.rs
+++ b/copyrite/src/checksum/file.rs
@@ -26,10 +26,10 @@ pub struct State {
 
 impl State {
     /// Build from a name.
-    pub async fn try_from(name: String, avoid_get_object_attributes: bool) -> Result<Self> {
+    pub async fn try_from(name: String, no_get_object_attributes: bool) -> Result<Self> {
         Ok(Self {
             object_sums: ObjectSumsBuilder::default()
-                .with_avoid_get_object_attributes(avoid_get_object_attributes)
+                .with_no_get_object_attributes(no_get_object_attributes)
                 .build(SumsFile::format_target_file(&name))
                 .await?,
             name,

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -97,6 +97,18 @@ impl Command {
             }
         }
 
+        // Source/destination-prefixed credential options are only valid for the `copy` command.
+        if !matches!(args.commands, Subcommands::Copy(_))
+            && args.credentials.has_prefixed_options()
+        {
+            return Err(ParseError(
+                "source and destination credential options are only available for the `copy` \
+                 command; use the unprefixed versions instead (e.g. `--credential-provider` \
+                 instead of `--source-credential-provider`)"
+                    .to_string(),
+            ));
+        }
+
         Ok(())
     }
 
@@ -1060,57 +1072,40 @@ impl Compatibility {
     }
 }
 
-/// Options related to credentials. Options prefixed with `source_` affect `check`, `generate` and
-/// the source of a `copy` command. These options also have an alias without the prefix as they are
-/// used in all commands. Options prefixed with `destination_` only affect the destination of a
-/// `copy` command.
+/// Options related to credentials. Unprefixed options apply to both source and destination. For
+/// `copy`, options can be prefixed with `source_` or `destination_` to target one side. `generate`
+/// and `check` only support the unprefixed version of options. Prefixed options take precedence
+/// over unprefixed options in copies.
 #[derive(Args, Debug)]
 #[group(required = false)]
 #[command(next_help_heading = "Credentials")]
 pub struct Credentials {
-    /// The credentials source credentials to use. This affects the credentials used for `check`
-    /// `generate` and the source of a `copy` operation.
+    /// The credential provider to use. Defaults to `default-environment` if not specified.
+    ///
+    /// For the copy command, each credential option can also be prefixed with
+    /// `source-` or `destination-` to target one side independently (e.g.
+    /// `--source-credential-provider`, `--destination-region`). When both prefixed and
+    /// unprefixed versions are specified, the prefixed version takes precedence.
+    /// Prefixed options are not available for `generate` or `check`.
     #[arg(
         global = true,
         long,
-        env = "COPYRITE_SOURCE_CREDENTIAL_PROVIDER",
-        default_value = "default-environment",
-        alias = "credential-provider",
-        requires_if("aws-profile", "source_profile"),
-        requires_if("aws-secret", "source_secret"),
+        env = "COPYRITE_CREDENTIAL_PROVIDER",
+        requires_if("aws-profile", "profile"),
+        requires_if("aws-secret", "secret"),
         hide_short_help = true
     )]
-    pub source_credential_provider: CredentialProvider,
-    /// The destination credentials to use. This only affects the credentials used for the
-    /// destination of a `copy` operation.
+    pub credential_provider: Option<CredentialProvider>,
+    /// The profile to use if the credential provider is `aws-profile`.
     #[arg(
         global = true,
         long,
-        env = "COPYRITE_DESTINATION_CREDENTIAL_PROVIDER",
-        default_value = "default-environment",
-        requires_if("aws-profile", "destination_profile"),
-        requires_if("aws-secret", "destination_secret"),
+        env = "COPYRITE_PROFILE",
+
         hide_short_help = true
     )]
-    pub destination_credential_provider: CredentialProvider,
-    /// The source profile to use if the source credential provider is `aws-profile`.
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_SOURCE_PROFILE",
-        alias = "profile",
-        hide_short_help = true
-    )]
-    pub source_profile: Option<String>,
-    /// The destination profile to use if the destination credential provider is `aws-profile`.
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_DESTINATION_PROFILE",
-        hide_short_help = true
-    )]
-    pub destination_profile: Option<String>,
-    /// The source secret name or ARN to use if the source credential provider is `aws-secret`.
+    pub profile: Option<String>,
+    /// The secret name or ARN to use if the credential provider is `aws-secret`.
     ///
     /// The secret must be a JSON object, with only `access_key_id` and `secret_access_key`
     /// being required:
@@ -1127,129 +1122,256 @@ pub struct Credentials {
     #[arg(
         global = true,
         long,
-        env = "COPYRITE_SOURCE_SECRET",
-        alias = "secret",
+        env = "COPYRITE_SECRET",
+
         hide_short_help = true,
         verbatim_doc_comment
     )]
-    pub source_secret: Option<String>,
-    /// The destination secret name or ARN to use if the destination credential provider is
-    /// `aws-secret`. See `--source-secret` for the expected JSON format.
+    pub secret: Option<String>,
+    /// Set the region for the credential provider.
     #[arg(
         global = true,
         long,
-        env = "COPYRITE_DESTINATION_SECRET",
+        env = "COPYRITE_REGION",
+
         hide_short_help = true
     )]
-    pub destination_secret: Option<String>,
-    /// Set the region for the source credential provider.
+    pub region: Option<String>,
+    /// Set the endpoint URL for AWS calls. This allows using a different endpoint that has an
+    /// S3-compatible storage API.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_ENDPOINT_URL",
+
+        hide_short_help = true
+    )]
+    pub endpoint_url: Option<String>,
+    /// The AWS access key ID. Overrides the value from the selected credential provider.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_ACCESS_KEY_ID",
+
+        hide_short_help = true
+    )]
+    pub access_key_id: Option<String>,
+    /// The AWS secret access key. Overrides the value from the selected credential provider.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_SECRET_ACCESS_KEY",
+
+        hide_short_help = true
+    )]
+    pub secret_access_key: Option<String>,
+    /// The AWS session token. Overrides the value from the selected credential provider.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_SESSION_TOKEN",
+
+        hide_short_help = true
+    )]
+    pub session_token: Option<String>,
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_SOURCE_CREDENTIAL_PROVIDER",
+        requires_if("aws-profile", "source_profile"),
+        requires_if("aws-secret", "source_secret"),
+        hide = true
+    )]
+    pub source_credential_provider: Option<CredentialProvider>,
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_SOURCE_PROFILE",
+        hide = true
+    )]
+    pub source_profile: Option<String>,
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_SOURCE_SECRET",
+        hide = true
+    )]
+    pub source_secret: Option<String>,
     #[arg(
         global = true,
         long,
         env = "COPYRITE_SOURCE_REGION",
-        alias = "region",
-        hide_short_help = true
+        hide = true
     )]
     pub source_region: Option<String>,
-    /// Set the region for the destination credential provider.
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_DESTINATION_REGION",
-        hide_short_help = true
-    )]
-    pub destination_region: Option<String>,
-    /// Set the source endpoint URL for AWS calls. This allows using a different endpoint that
-    /// has an S3-compatible storage API.
     #[arg(
         global = true,
         long,
         env = "COPYRITE_SOURCE_ENDPOINT_URL",
-        alias = "endpoint-url",
-        hide_short_help = true
+        hide = true
     )]
     pub source_endpoint_url: Option<String>,
-    /// Set the destination endpoint URL for AWS calls. This allows using a different endpoint
-    /// that has an S3-compatible storage API.
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_DESTINATION_ENDPOINT_URL",
-        hide_short_help = true
-    )]
-    pub destination_endpoint_url: Option<String>,
-    /// The source AWS access key ID. Overrides the value from the selected credential provider.
     #[arg(
         global = true,
         long,
         env = "COPYRITE_SOURCE_ACCESS_KEY_ID",
-        alias = "access-key-id",
-        hide_short_help = true
+        hide = true
     )]
     pub source_access_key_id: Option<String>,
-    /// The source AWS secret access key. Overrides the value from the selected credential
-    /// provider.
     #[arg(
         global = true,
         long,
         env = "COPYRITE_SOURCE_SECRET_ACCESS_KEY",
-        alias = "secret-access-key",
-        hide_short_help = true
+        hide = true
     )]
     pub source_secret_access_key: Option<String>,
-    /// The source AWS session token. Overrides the value from the selected credential provider.
     #[arg(
         global = true,
         long,
         env = "COPYRITE_SOURCE_SESSION_TOKEN",
-        alias = "session-token",
-        hide_short_help = true
+        hide = true
     )]
     pub source_session_token: Option<String>,
-    /// The destination AWS access key ID. Overrides the value from the selected credential
-    /// provider.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_DESTINATION_CREDENTIAL_PROVIDER",
+        requires_if("aws-profile", "destination_profile"),
+        requires_if("aws-secret", "destination_secret"),
+        hide = true
+    )]
+    pub destination_credential_provider: Option<CredentialProvider>,
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_DESTINATION_PROFILE",
+        hide = true
+    )]
+    pub destination_profile: Option<String>,
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_DESTINATION_SECRET",
+        hide = true
+    )]
+    pub destination_secret: Option<String>,
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_DESTINATION_REGION",
+        hide = true
+    )]
+    pub destination_region: Option<String>,
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_DESTINATION_ENDPOINT_URL",
+        hide = true
+    )]
+    pub destination_endpoint_url: Option<String>,
     #[arg(
         global = true,
         long,
         env = "COPYRITE_DESTINATION_ACCESS_KEY_ID",
-        hide_short_help = true
+        hide = true
     )]
     pub destination_access_key_id: Option<String>,
-    /// The destination AWS secret access key. Overrides the value from the selected credential
-    /// provider.
     #[arg(
         global = true,
         long,
         env = "COPYRITE_DESTINATION_SECRET_ACCESS_KEY",
-        hide_short_help = true
+        hide = true
     )]
     pub destination_secret_access_key: Option<String>,
-    /// The destination AWS session token. Overrides the value from the selected credential
-    /// provider.
     #[arg(
         global = true,
         long,
         env = "COPYRITE_DESTINATION_SESSION_TOKEN",
-        hide_short_help = true
+        hide = true
     )]
     pub destination_session_token: Option<String>,
 }
 
 impl Credentials {
+    /// Resolve the effective source credential provider.
+    fn effective_source_credential_provider(&self) -> CredentialProvider {
+        self.source_credential_provider
+            .or(self.credential_provider)
+            .unwrap_or_default()
+    }
+
+    /// Resolve the effective destination credential provider.
+    fn effective_destination_credential_provider(&self) -> CredentialProvider {
+        self.destination_credential_provider
+            .or(self.credential_provider)
+            .unwrap_or_default()
+    }
+
+    /// Resolve the effective source profile.
+    fn effective_source_profile(&self) -> Option<&str> {
+        self.source_profile
+            .as_deref()
+            .or(self.profile.as_deref())
+    }
+
+    /// Resolve the effective destination profile.
+    fn effective_destination_profile(&self) -> Option<&str> {
+        self.destination_profile
+            .as_deref()
+            .or(self.profile.as_deref())
+    }
+
+    /// Resolve the effective source secret.
+    fn effective_source_secret(&self) -> Option<&str> {
+        self.source_secret
+            .as_deref()
+            .or(self.secret.as_deref())
+    }
+
+    /// Resolve the effective destination secret.
+    fn effective_destination_secret(&self) -> Option<&str> {
+        self.destination_secret
+            .as_deref()
+            .or(self.secret.as_deref())
+    }
+
+    /// Resolve the effective source region.
+    fn effective_source_region(&self) -> Option<&str> {
+        self.source_region
+            .as_deref()
+            .or(self.region.as_deref())
+    }
+
+    /// Resolve the effective destination region.
+    fn effective_destination_region(&self) -> Option<&str> {
+        self.destination_region
+            .as_deref()
+            .or(self.region.as_deref())
+    }
+
+    /// Resolve the effective source endpoint URL.
+    fn effective_source_endpoint_url(&self) -> Option<&str> {
+        self.source_endpoint_url
+            .as_deref()
+            .or(self.endpoint_url.as_deref())
+    }
+
+    /// Resolve the effective destination endpoint URL.
+    fn effective_destination_endpoint_url(&self) -> Option<&str> {
+        self.destination_endpoint_url
+            .as_deref()
+            .or(self.endpoint_url.as_deref())
+    }
+
     /// Construct the source client from the credentials.
     pub async fn source_client(&self, compatibility: &Compatibility) -> Result<Client> {
-        let overrides = CredentialOverrides::new(
-            self.source_access_key_id.clone(),
-            self.source_secret_access_key.clone(),
-            self.source_session_token.clone(),
-        );
         create_s3_client(
-            &self.source_credential_provider,
-            self.source_profile.as_deref(),
-            self.source_region.as_deref(),
-            self.source_endpoint_url.as_deref(),
-            self.source_secret.as_deref(),
-            overrides,
+            &self.effective_source_credential_provider(),
+            self.effective_source_profile(),
+            self.effective_source_region(),
+            self.effective_source_endpoint_url(),
+            self.effective_source_secret(),
+            self.source_overrides(),
             compatibility.force_path_style(),
         )
         .await
@@ -1257,18 +1379,13 @@ impl Credentials {
 
     /// Construct the destination client from the credentials.
     pub async fn destination_client(&self, compatibility: &Compatibility) -> Result<Client> {
-        let overrides = CredentialOverrides::new(
-            self.destination_access_key_id.clone(),
-            self.destination_secret_access_key.clone(),
-            self.destination_session_token.clone(),
-        );
         create_s3_client(
-            &self.destination_credential_provider,
-            self.destination_profile.as_deref(),
-            self.destination_region.as_deref(),
-            self.destination_endpoint_url.as_deref(),
-            self.destination_secret.as_deref(),
-            overrides,
+            &self.effective_destination_credential_provider(),
+            self.effective_destination_profile(),
+            self.effective_destination_region(),
+            self.effective_destination_endpoint_url(),
+            self.effective_destination_secret(),
+            self.destination_overrides(),
             compatibility.force_path_style(),
         )
         .await
@@ -1276,27 +1393,59 @@ impl Credentials {
 
     /// Check if the default credentials are being used without any overrides.
     pub fn is_default(&self) -> bool {
-        self.source_credential_provider.is_default()
-            && self.destination_credential_provider.is_default()
-            && self.source_endpoint_url.is_none()
-            && self.destination_endpoint_url.is_none()
+        self.effective_source_credential_provider().is_default()
+            && self.effective_destination_credential_provider().is_default()
+            && self.effective_source_endpoint_url().is_none()
+            && self.effective_destination_endpoint_url().is_none()
             && !self.source_overrides().any()
             && !self.destination_overrides().any()
     }
 
+    /// Check if any source or destination specific options are set.
+    pub fn has_prefixed_options(&self) -> bool {
+        self.source_credential_provider.is_some()
+            || self.destination_credential_provider.is_some()
+            || self.source_profile.is_some()
+            || self.destination_profile.is_some()
+            || self.source_secret.is_some()
+            || self.destination_secret.is_some()
+            || self.source_region.is_some()
+            || self.destination_region.is_some()
+            || self.source_endpoint_url.is_some()
+            || self.destination_endpoint_url.is_some()
+            || self.source_access_key_id.is_some()
+            || self.destination_access_key_id.is_some()
+            || self.source_secret_access_key.is_some()
+            || self.destination_secret_access_key.is_some()
+            || self.source_session_token.is_some()
+            || self.destination_session_token.is_some()
+    }
+
     fn source_overrides(&self) -> CredentialOverrides {
         CredentialOverrides::new(
-            self.source_access_key_id.clone(),
-            self.source_secret_access_key.clone(),
-            self.source_session_token.clone(),
+            self.source_access_key_id
+                .clone()
+                .or(self.access_key_id.clone()),
+            self.source_secret_access_key
+                .clone()
+                .or(self.secret_access_key.clone()),
+            self.source_session_token
+                .clone()
+                .or(self.session_token.clone()),
         )
     }
 
     fn destination_overrides(&self) -> CredentialOverrides {
         CredentialOverrides::new(
-            self.destination_access_key_id.clone(),
-            self.destination_secret_access_key.clone(),
-            self.destination_session_token.clone(),
+            self.destination_access_key_id
+                .clone()
+                .or(self.access_key_id.clone()),
+            self.destination_secret_access_key
+                .clone()
+                .or(self.secret_access_key.clone()),
+            self.destination_session_token
+                .clone()
+                .or(self.session_token.clone()),
         )
     }
 }

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -5,6 +5,7 @@ use crate::checksum::Ctx;
 use crate::error::Error;
 use crate::error::Error::{CheckError, GenerateError, ParseError};
 use crate::error::Result;
+use crate::io::S3Client;
 use crate::io::sums::ObjectSumsBuilder;
 use crate::io::sums::channel::ChannelReader;
 use crate::io::{CredentialOverrides, Provider, create_s3_client, default_s3_client};
@@ -13,7 +14,6 @@ use crate::stats::{CheckStats, ChecksumPair, CopyStats, GenerateStats};
 use crate::task::check::{CheckTask, CheckTaskBuilder, GroupBy};
 use crate::task::copy::CopyTaskBuilder;
 use crate::task::generate::{GenerateTaskBuilder, SumCtxPairs};
-use aws_sdk_s3::Client;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use console::style;
 use humantime::Duration;
@@ -97,14 +97,12 @@ impl Command {
             }
         }
 
-        // Source/destination-prefixed credential options are only valid for the `copy` command.
         if !matches!(args.commands, Subcommands::Copy(_))
-            && args.credentials.has_prefixed_options()
+            && (args.credentials.has_prefixed_options()
+                || args.compatibility.has_prefixed_options())
         {
             return Err(ParseError(
-                "source and destination credential options are only available for the `copy` \
-                 command; use the unprefixed versions instead (e.g. `--credential-provider` \
-                 instead of `--source-credential-provider`)"
+                "source and destination options are only available for the `copy` command, use the unprefixed versions instead (e.g. `--credential-provider`)"
                     .to_string(),
             ));
         }
@@ -115,11 +113,9 @@ impl Command {
     /// Execute the command from the args.
     pub async fn execute(self) -> Result<()> {
         let now = Instant::now();
-        let client = Arc::new(
-            self.credentials
-                .source_client(&self.compatibility)
-                .await?,
-        );
+        let client = self.credentials
+            .source_client(&self.compatibility)
+            .await?;
 
         let pretty_json = self.output.pretty_json;
         let write_sums_file = self.output.write_sums_file;
@@ -130,7 +126,6 @@ impl Command {
                 let stats = generate_args
                     .generate(
                         self.optimization,
-                        &self.compatibility,
                         vec![client],
                         true,
                     )
@@ -147,7 +142,6 @@ impl Command {
                 let output = check_args
                     .check(
                         self.optimization,
-                        &self.compatibility,
                         write_sums_file,
                         false,
                         vec![client],
@@ -158,18 +152,15 @@ impl Command {
                 Self::print_stats(&output, pretty_json, ui)?;
             }
             Subcommands::Copy(copy_args) => {
-                let destination_client = Arc::new(
-                    self.credentials
-                        .destination_client(&self.compatibility)
-                        .await?,
-                );
+                let destination_client = self.credentials
+                    .destination_client(&self.compatibility)
+                    .await?;
 
                 let output = copy_args
                     .copy(
                         client,
                         destination_client,
                         self.credentials,
-                        self.compatibility,
                         self.optimization,
                         write_sums_file,
                         ui,
@@ -271,16 +262,13 @@ impl Generate {
     pub async fn generate(
         self,
         optimization: Optimization,
-        compatibility: &Compatibility,
-        mut clients: Vec<Arc<Client>>,
+        mut clients: Vec<S3Client>,
         write_sums_file: bool,
     ) -> stats::Result<GenerateStats> {
         if self.input[0] == "-" {
             let reader = ChannelReader::new(stdin(), optimization.channel_capacity);
 
             let output = GenerateTaskBuilder::default()
-                .with_no_get_object_attributes(compatibility.no_get_object_attributes())
-                .with_no_checksum_mode(compatibility.no_checksum_mode())
                 .with_overwrite(self.force_overwrite)
                 .with_verify(self.verify)
                 .with_context(self.checksum)
@@ -309,8 +297,6 @@ impl Generate {
                 let (ctxs, group_by) = Check::comparable_check(
                     self.input.clone(),
                     clients.clone(),
-                    compatibility.no_get_object_attributes(),
-                    compatibility.no_checksum_mode(),
                 )
                 .await?;
                 let (objects, compared, updated, api_errors) = ctxs.into_inner();
@@ -327,7 +313,7 @@ impl Generate {
                 );
 
                 if clients.is_empty() {
-                    clients = vec![Arc::new(default_s3_client().await?)];
+                    clients = vec![S3Client::new(Arc::new(default_s3_client().await?), false, false)];
                 }
 
                 let ctxs = SumCtxPairs::from_comparable(objects)?;
@@ -339,10 +325,6 @@ impl Generate {
                     {
                         let (input, ctx) = ctx.into_inner();
                         let task = GenerateTaskBuilder::default()
-                            .with_no_get_object_attributes(
-                                compatibility.no_get_object_attributes(),
-                            )
-                            .with_no_checksum_mode(compatibility.no_checksum_mode())
                             .with_overwrite(self.force_overwrite)
                             .with_verify(self.verify)
                             .with_input_file_name(input.to_string())
@@ -373,8 +355,6 @@ impl Generate {
 
             for (input, client) in self.input.into_iter().zip(clients.into_iter().cycle()) {
                 let task = GenerateTaskBuilder::default()
-                    .with_no_get_object_attributes(compatibility.no_get_object_attributes())
-                    .with_no_checksum_mode(compatibility.no_checksum_mode())
                     .with_overwrite(self.force_overwrite)
                     .with_verify(self.verify)
                     .with_input_file_name(input.to_string())
@@ -433,16 +413,12 @@ impl Check {
     /// Perform a check for comparability on the input files.
     pub async fn comparable_check(
         input: Vec<String>,
-        clients: Vec<Arc<Client>>,
-        no_get_object_attributes: bool,
-        no_checksum_mode: bool,
+        clients: Vec<S3Client>,
     ) -> Result<(CheckTask, GroupBy)> {
         Ok((
             CheckTaskBuilder::default()
                 .with_input_files(input)
                 .with_group_by(GroupBy::Comparability)
-                .with_no_get_object_attributes(no_get_object_attributes)
-                .with_no_checksum_mode(no_checksum_mode)
                 .with_clients(clients)
                 .build()
                 .await?
@@ -465,18 +441,15 @@ impl Check {
     pub async fn check(
         self,
         optimization: Optimization,
-        compatibility: &Compatibility,
         write_sums_file: bool,
         verify: bool,
-        clients: Vec<Arc<Client>>,
+        clients: Vec<S3Client>,
     ) -> stats::Result<CheckStats> {
         let now = Instant::now();
         let group_by = self.group_by;
 
         let mut builder = CheckTaskBuilder::default()
             .with_group_by(group_by)
-            .with_no_get_object_attributes(compatibility.no_get_object_attributes())
-            .with_no_checksum_mode(compatibility.no_checksum_mode())
             .with_input_files(self.input.clone())
             .with_update(self.update)
             .with_clients(clients.clone());
@@ -485,8 +458,6 @@ impl Check {
             let (ctxs, _) = Check::comparable_check(
                 self.input.clone(),
                 clients.clone(),
-                compatibility.no_get_object_attributes(),
-                compatibility.no_checksum_mode(),
             )
             .await?;
             let checksum = Check::generate_sums(ctxs);
@@ -498,7 +469,7 @@ impl Check {
                 force_overwrite: false,
                 verify,
             }
-            .generate(optimization, compatibility, clients.clone(), write_sums_file)
+            .generate(optimization, clients.clone(), write_sums_file)
             .await
             .map_err(|stats| CheckStats::from_generate_task(group_by, *stats))?;
             let sums = stats
@@ -677,10 +648,9 @@ pub struct Copy {
 impl Copy {
     pub async fn copy_check(
         &self,
-        source_client: Arc<Client>,
-        destination_client: Arc<Client>,
+        source_client: S3Client,
+        destination_client: S3Client,
         optimization: Optimization,
-        compatibility: &Compatibility,
         verify: bool,
         write_sums_file: bool,
     ) -> stats::Result<CheckStats> {
@@ -694,7 +664,6 @@ impl Copy {
         }
         .check(
             optimization,
-            compatibility,
             write_sums_file,
             verify,
             vec![source_client, destination_client],
@@ -707,10 +676,9 @@ impl Copy {
     /// Perform the copy sub command from the args.
     pub async fn copy(
         self,
-        source_client: Arc<Client>,
-        destination_client: Arc<Client>,
+        source_client: S3Client,
+        destination_client: S3Client,
         credentials: Credentials,
-        compatibility: Compatibility,
         optimization: Optimization,
         write_sums_file: bool,
         ui: bool,
@@ -726,8 +694,6 @@ impl Copy {
             // Check if it exists in the first place.
             let file_size = ObjectSumsBuilder::default()
                 .set_client(Some(destination_client.clone()))
-                .with_no_get_object_attributes(compatibility.no_get_object_attributes())
-                .with_no_checksum_mode(compatibility.no_checksum_mode())
                 .build(self.destination.to_string())
                 .await?
                 .file_size()
@@ -743,7 +709,6 @@ impl Copy {
                         source_client.clone(),
                         destination_client.clone(),
                         optimization.clone(),
-                        &compatibility,
                         false,
                         write_sums_file,
                     )
@@ -818,8 +783,6 @@ impl Copy {
             .with_metadata_mode(self.metadata_mode)
             .with_tag_mode(self.tag_mode)
             .with_multipart_threshold(self.multipart_threshold)
-            .with_no_get_object_attributes(compatibility.no_get_object_attributes())
-            .with_no_checksum_mode(compatibility.no_checksum_mode())
             .with_concurrency(self.concurrency)
             .with_part_size(self.part_size)
             .with_ui(ui)
@@ -843,7 +806,6 @@ impl Copy {
                     source_client,
                     destination_client,
                     optimization,
-                    &compatibility,
                     sums_mismatch,
                     write_sums_file,
                 )
@@ -999,8 +961,11 @@ pub struct Output {
     pub write_sums_file: bool,
 }
 
-/// Options related to increasing compatibility with S3-compatible storage. These options are
-/// useful when using an S3-compatible endpoint that does not support all S3 features.
+/// Options related to increasing compatibility with S3-compatible storage. For
+/// `copy`, options can be prefixed with `source_` or `destination_` to target one side.
+/// `generate` and `check` only support the unprefixed version of options. Prefixed
+/// options enable additional compatibility for the side, and unprefixed options enable
+/// it for both sides.
 #[derive(Args, Debug, Clone)]
 #[group(required = false)]
 #[command(next_help_heading = "Compatibility")]
@@ -1009,6 +974,12 @@ pub struct Compatibility {
     ///
     /// This is a convenience flag that enables `--force-path-style`,
     /// `--no-get-object-attributes`, and `--no-checksum-mode`.
+    ///
+    /// For the copy command, each compatibility option can also be prefixed with
+    /// `source-` or `destination-` to enable additional compatibility per-side (e.g.
+    /// `--source-force-path-style`, `--destination-no-checksum-mode`). Unprefixed
+    /// options apply to both sides whereas prefixed options enable compatibility for
+    /// that side only. Prefixed options are not available for `generate` or `check`.
     #[arg(
         global = true,
         long,
@@ -1053,6 +1024,22 @@ pub struct Compatibility {
         hide_short_help = true
     )]
     pub no_checksum_mode: bool,
+    #[arg(global = true, long, env = "COPYRITE_SOURCE_S3_COMPATIBLE", hide = true)]
+    pub source_s3_compatible: bool,
+    #[arg(global = true, long, env = "COPYRITE_SOURCE_FORCE_PATH_STYLE", hide = true)]
+    pub source_force_path_style: bool,
+    #[arg(global = true, long, env = "COPYRITE_SOURCE_NO_GET_OBJECT_ATTRIBUTES", hide = true)]
+    pub source_no_get_object_attributes: bool,
+    #[arg(global = true, long, env = "COPYRITE_SOURCE_NO_CHECKSUM_MODE", hide = true)]
+    pub source_no_checksum_mode: bool,
+    #[arg(global = true, long, env = "COPYRITE_DESTINATION_S3_COMPATIBLE", hide = true)]
+    pub destination_s3_compatible: bool,
+    #[arg(global = true, long, env = "COPYRITE_DESTINATION_FORCE_PATH_STYLE", hide = true)]
+    pub destination_force_path_style: bool,
+    #[arg(global = true, long, env = "COPYRITE_DESTINATION_NO_GET_OBJECT_ATTRIBUTES", hide = true)]
+    pub destination_no_get_object_attributes: bool,
+    #[arg(global = true, long, env = "COPYRITE_DESTINATION_NO_CHECKSUM_MODE", hide = true)]
+    pub destination_no_checksum_mode: bool,
 }
 
 impl Compatibility {
@@ -1070,6 +1057,61 @@ impl Compatibility {
     pub fn no_checksum_mode(&self) -> bool {
         self.s3_compatible || self.no_checksum_mode
     }
+
+    /// Whether to force path-style addressing for the source.
+    pub fn source_force_path_style(&self) -> bool {
+        self.source_s3_compatible
+            || self.source_force_path_style
+            || self.force_path_style()
+    }
+
+    /// Whether to force path-style addressing for the destination.
+    pub fn destination_force_path_style(&self) -> bool {
+        self.destination_s3_compatible
+            || self.destination_force_path_style
+            || self.force_path_style()
+    }
+
+    /// Whether to avoid `GetObjectAttributes` calls for the source.
+    pub fn source_no_get_object_attributes(&self) -> bool {
+        self.source_s3_compatible
+            || self.source_no_get_object_attributes
+            || self.no_get_object_attributes()
+    }
+
+    /// Whether to avoid `GetObjectAttributes` calls for the destination.
+    pub fn destination_no_get_object_attributes(&self) -> bool {
+        self.destination_s3_compatible
+            || self.destination_no_get_object_attributes
+            || self.no_get_object_attributes()
+    }
+
+    /// Whether to disable checksum mode for the source.
+    pub fn source_no_checksum_mode(&self) -> bool {
+        self.source_s3_compatible
+            || self.source_no_checksum_mode
+            || self.no_checksum_mode()
+    }
+
+    /// Whether to disable checksum mode for the destination.
+    pub fn destination_no_checksum_mode(&self) -> bool {
+        self.destination_s3_compatible
+            || self.destination_no_checksum_mode
+            || self.no_checksum_mode()
+    }
+
+    /// Check if any source or destination specific options are set.
+    pub fn has_prefixed_options(&self) -> bool {
+        self.source_s3_compatible
+            || self.source_force_path_style
+            || self.source_no_get_object_attributes
+            || self.source_no_checksum_mode
+            || self.destination_s3_compatible
+            || self.destination_force_path_style
+            || self.destination_no_get_object_attributes
+            || self.destination_no_checksum_mode
+    }
+
 }
 
 /// Options related to credentials. Unprefixed options apply to both source and destination. For
@@ -1364,31 +1406,41 @@ impl Credentials {
     }
 
     /// Construct the source client from the credentials.
-    pub async fn source_client(&self, compatibility: &Compatibility) -> Result<Client> {
-        create_s3_client(
+    pub async fn source_client(&self, compatibility: &Compatibility) -> Result<S3Client> {
+        let client = create_s3_client(
             &self.effective_source_credential_provider(),
             self.effective_source_profile(),
             self.effective_source_region(),
             self.effective_source_endpoint_url(),
             self.effective_source_secret(),
             self.source_overrides(),
-            compatibility.force_path_style(),
+            compatibility.source_force_path_style(),
         )
-        .await
+        .await?;
+        Ok(S3Client::new(
+            Arc::new(client),
+            compatibility.source_no_get_object_attributes(),
+            compatibility.source_no_checksum_mode(),
+        ))
     }
 
     /// Construct the destination client from the credentials.
-    pub async fn destination_client(&self, compatibility: &Compatibility) -> Result<Client> {
-        create_s3_client(
+    pub async fn destination_client(&self, compatibility: &Compatibility) -> Result<S3Client> {
+        let client = create_s3_client(
             &self.effective_destination_credential_provider(),
             self.effective_destination_profile(),
             self.effective_destination_region(),
             self.effective_destination_endpoint_url(),
             self.effective_destination_secret(),
             self.destination_overrides(),
-            compatibility.force_path_style(),
+            compatibility.destination_force_path_style(),
         )
-        .await
+        .await?;
+        Ok(S3Client::new(
+            Arc::new(client),
+            compatibility.destination_no_get_object_attributes(),
+            compatibility.destination_no_checksum_mode(),
+        ))
     }
 
     /// Check if the default credentials are being used without any overrides.

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -8,7 +8,7 @@ use crate::error::Result;
 use crate::io::S3Client;
 use crate::io::sums::ObjectSumsBuilder;
 use crate::io::sums::channel::ChannelReader;
-use crate::io::{CredentialOverrides, Provider, create_s3_client, default_s3_client};
+use crate::io::{CredentialOverrides, Provider};
 use crate::stats;
 use crate::stats::{CheckStats, ChecksumPair, CopyStats, GenerateStats};
 use crate::task::check::{CheckTask, CheckTaskBuilder, GroupBy};
@@ -313,7 +313,7 @@ impl Generate {
                 );
 
                 if clients.is_empty() {
-                    clients = vec![S3Client::new(Arc::new(default_s3_client().await?), false, false)];
+                    clients = vec![S3Client::new(Arc::new(S3Client::default_s3_client().await?), false, false)];
                 }
 
                 let ctxs = SumCtxPairs::from_comparable(objects)?;
@@ -1100,7 +1100,7 @@ impl Compatibility {
             || self.no_checksum_mode()
     }
 
-    /// Check if any source or destination specific options are set.
+    /// Check if any source or destination options are set.
     pub fn has_prefixed_options(&self) -> bool {
         self.source_s3_compatible
             || self.source_force_path_style
@@ -1336,70 +1336,70 @@ pub struct Credentials {
 
 impl Credentials {
     /// Resolve the effective source credential provider.
-    fn effective_source_credential_provider(&self) -> CredentialProvider {
+    pub fn effective_source_credential_provider(&self) -> CredentialProvider {
         self.source_credential_provider
             .or(self.credential_provider)
             .unwrap_or_default()
     }
 
     /// Resolve the effective destination credential provider.
-    fn effective_destination_credential_provider(&self) -> CredentialProvider {
+    pub fn effective_destination_credential_provider(&self) -> CredentialProvider {
         self.destination_credential_provider
             .or(self.credential_provider)
             .unwrap_or_default()
     }
 
     /// Resolve the effective source profile.
-    fn effective_source_profile(&self) -> Option<&str> {
+    pub fn effective_source_profile(&self) -> Option<&str> {
         self.source_profile
             .as_deref()
             .or(self.profile.as_deref())
     }
 
     /// Resolve the effective destination profile.
-    fn effective_destination_profile(&self) -> Option<&str> {
+    pub fn effective_destination_profile(&self) -> Option<&str> {
         self.destination_profile
             .as_deref()
             .or(self.profile.as_deref())
     }
 
     /// Resolve the effective source secret.
-    fn effective_source_secret(&self) -> Option<&str> {
+    pub fn effective_source_secret(&self) -> Option<&str> {
         self.source_secret
             .as_deref()
             .or(self.secret.as_deref())
     }
 
     /// Resolve the effective destination secret.
-    fn effective_destination_secret(&self) -> Option<&str> {
+    pub fn effective_destination_secret(&self) -> Option<&str> {
         self.destination_secret
             .as_deref()
             .or(self.secret.as_deref())
     }
 
     /// Resolve the effective source region.
-    fn effective_source_region(&self) -> Option<&str> {
+    pub fn effective_source_region(&self) -> Option<&str> {
         self.source_region
             .as_deref()
             .or(self.region.as_deref())
     }
 
     /// Resolve the effective destination region.
-    fn effective_destination_region(&self) -> Option<&str> {
+    pub fn effective_destination_region(&self) -> Option<&str> {
         self.destination_region
             .as_deref()
             .or(self.region.as_deref())
     }
 
     /// Resolve the effective source endpoint URL.
-    fn effective_source_endpoint_url(&self) -> Option<&str> {
+    pub fn effective_source_endpoint_url(&self) -> Option<&str> {
         self.source_endpoint_url
             .as_deref()
             .or(self.endpoint_url.as_deref())
     }
 
     /// Resolve the effective destination endpoint URL.
-    fn effective_destination_endpoint_url(&self) -> Option<&str> {
+    pub fn effective_destination_endpoint_url(&self) -> Option<&str> {
         self.destination_endpoint_url
             .as_deref()
             .or(self.endpoint_url.as_deref())
@@ -1407,40 +1407,18 @@ impl Credentials {
 
     /// Construct the source client from the credentials.
     pub async fn source_client(&self, compatibility: &Compatibility) -> Result<S3Client> {
-        let client = create_s3_client(
-            &self.effective_source_credential_provider(),
-            self.effective_source_profile(),
-            self.effective_source_region(),
-            self.effective_source_endpoint_url(),
-            self.effective_source_secret(),
-            self.source_overrides(),
-            compatibility.source_force_path_style(),
-        )
-        .await?;
-        Ok(S3Client::new(
-            Arc::new(client),
-            compatibility.source_no_get_object_attributes(),
-            compatibility.source_no_checksum_mode(),
-        ))
+        S3Client::new_from_cli_source(
+            self,
+            compatibility
+        ).await
     }
 
     /// Construct the destination client from the credentials.
     pub async fn destination_client(&self, compatibility: &Compatibility) -> Result<S3Client> {
-        let client = create_s3_client(
-            &self.effective_destination_credential_provider(),
-            self.effective_destination_profile(),
-            self.effective_destination_region(),
-            self.effective_destination_endpoint_url(),
-            self.effective_destination_secret(),
-            self.destination_overrides(),
-            compatibility.destination_force_path_style(),
-        )
-        .await?;
-        Ok(S3Client::new(
-            Arc::new(client),
-            compatibility.destination_no_get_object_attributes(),
-            compatibility.destination_no_checksum_mode(),
-        ))
+        S3Client::new_from_cli_destination(
+            self,
+            compatibility
+        ).await
     }
 
     /// Check if the default credentials are being used without any overrides.
@@ -1453,7 +1431,7 @@ impl Credentials {
             && !self.destination_overrides().any()
     }
 
-    /// Check if any source or destination specific options are set.
+    /// Check if any source or destination options are set.
     pub fn has_prefixed_options(&self) -> bool {
         self.source_credential_provider.is_some()
             || self.destination_credential_provider.is_some()
@@ -1473,7 +1451,7 @@ impl Credentials {
             || self.destination_session_token.is_some()
     }
 
-    fn source_overrides(&self) -> CredentialOverrides {
+    pub fn source_overrides(&self) -> CredentialOverrides {
         CredentialOverrides::new(
             self.source_access_key_id
                 .clone()
@@ -1487,7 +1465,7 @@ impl Credentials {
         )
     }
 
-    fn destination_overrides(&self) -> CredentialOverrides {
+    pub fn destination_overrides(&self) -> CredentialOverrides {
         CredentialOverrides::new(
             self.destination_access_key_id
                 .clone()

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -26,7 +26,6 @@ use std::ffi::OsString;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::stdin;
 
@@ -262,7 +261,7 @@ impl Generate {
     pub async fn generate(
         self,
         optimization: Optimization,
-        mut clients: Vec<S3Client>,
+        clients: Vec<S3Client>,
         write_sums_file: bool,
     ) -> stats::Result<GenerateStats> {
         if self.input[0] == "-" {
@@ -311,10 +310,6 @@ impl Generate {
                     )
                     .with_elapsed(now.elapsed()),
                 );
-
-                if clients.is_empty() {
-                    clients = vec![S3Client::new(Arc::new(S3Client::default_s3_client().await?), false, false)];
-                }
 
                 let ctxs = SumCtxPairs::from_comparable(objects)?;
                 if let Some(ctxs) = ctxs {

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -50,6 +50,9 @@ pub struct Command {
     /// Options related to credentials.
     #[command(flatten)]
     pub credentials: Credentials,
+    /// Options related to S3-compatible storage compatibility.
+    #[command(flatten)]
+    pub compatibility: Compatibility,
 }
 
 impl Command {
@@ -100,7 +103,11 @@ impl Command {
     /// Execute the command from the args.
     pub async fn execute(self) -> Result<()> {
         let now = Instant::now();
-        let client = Arc::new(self.credentials.source_client().await?);
+        let client = Arc::new(
+            self.credentials
+                .source_client(&self.compatibility)
+                .await?,
+        );
 
         let pretty_json = self.output.pretty_json;
         let write_sums_file = self.output.write_sums_file;
@@ -109,7 +116,12 @@ impl Command {
         match self.commands {
             Subcommands::Generate(generate_args) => {
                 let stats = generate_args
-                    .generate(self.optimization, &self.credentials, vec![client], true)
+                    .generate(
+                        self.optimization,
+                        &self.compatibility,
+                        vec![client],
+                        true,
+                    )
                     .await
                     .map_err(|err| Box::new(err.with_elapsed(now.elapsed())))?;
                 if let Some(sums) = stats.sums {
@@ -123,7 +135,7 @@ impl Command {
                 let output = check_args
                     .check(
                         self.optimization,
-                        &self.credentials,
+                        &self.compatibility,
                         write_sums_file,
                         false,
                         vec![client],
@@ -134,13 +146,18 @@ impl Command {
                 Self::print_stats(&output, pretty_json, ui)?;
             }
             Subcommands::Copy(copy_args) => {
-                let destination_client = Arc::new(self.credentials.destination_client().await?);
+                let destination_client = Arc::new(
+                    self.credentials
+                        .destination_client(&self.compatibility)
+                        .await?,
+                );
 
                 let output = copy_args
                     .copy(
                         client,
                         destination_client,
                         self.credentials,
+                        self.compatibility,
                         self.optimization,
                         write_sums_file,
                         ui,
@@ -242,7 +259,7 @@ impl Generate {
     pub async fn generate(
         self,
         optimization: Optimization,
-        credentials: &Credentials,
+        compatibility: &Compatibility,
         mut clients: Vec<Arc<Client>>,
         write_sums_file: bool,
     ) -> stats::Result<GenerateStats> {
@@ -250,7 +267,8 @@ impl Generate {
             let reader = ChannelReader::new(stdin(), optimization.channel_capacity);
 
             let output = GenerateTaskBuilder::default()
-                .with_avoid_get_object_attributes(credentials.avoid_get_object_attributes)
+                .with_no_get_object_attributes(compatibility.no_get_object_attributes())
+                .with_no_checksum_mode(compatibility.no_checksum_mode())
                 .with_overwrite(self.force_overwrite)
                 .with_verify(self.verify)
                 .with_context(self.checksum)
@@ -279,7 +297,8 @@ impl Generate {
                 let (ctxs, group_by) = Check::comparable_check(
                     self.input.clone(),
                     clients.clone(),
-                    credentials.avoid_get_object_attributes,
+                    compatibility.no_get_object_attributes(),
+                    compatibility.no_checksum_mode(),
                 )
                 .await?;
                 let (objects, compared, updated, api_errors) = ctxs.into_inner();
@@ -308,9 +327,10 @@ impl Generate {
                     {
                         let (input, ctx) = ctx.into_inner();
                         let task = GenerateTaskBuilder::default()
-                            .with_avoid_get_object_attributes(
-                                credentials.avoid_get_object_attributes,
+                            .with_no_get_object_attributes(
+                                compatibility.no_get_object_attributes(),
                             )
+                            .with_no_checksum_mode(compatibility.no_checksum_mode())
                             .with_overwrite(self.force_overwrite)
                             .with_verify(self.verify)
                             .with_input_file_name(input.to_string())
@@ -341,7 +361,8 @@ impl Generate {
 
             for (input, client) in self.input.into_iter().zip(clients.into_iter().cycle()) {
                 let task = GenerateTaskBuilder::default()
-                    .with_avoid_get_object_attributes(credentials.avoid_get_object_attributes)
+                    .with_no_get_object_attributes(compatibility.no_get_object_attributes())
+                    .with_no_checksum_mode(compatibility.no_checksum_mode())
                     .with_overwrite(self.force_overwrite)
                     .with_verify(self.verify)
                     .with_input_file_name(input.to_string())
@@ -401,13 +422,15 @@ impl Check {
     pub async fn comparable_check(
         input: Vec<String>,
         clients: Vec<Arc<Client>>,
-        avoid_get_object_attributes: bool,
+        no_get_object_attributes: bool,
+        no_checksum_mode: bool,
     ) -> Result<(CheckTask, GroupBy)> {
         Ok((
             CheckTaskBuilder::default()
                 .with_input_files(input)
                 .with_group_by(GroupBy::Comparability)
-                .with_avoid_get_object_attributes(avoid_get_object_attributes)
+                .with_no_get_object_attributes(no_get_object_attributes)
+                .with_no_checksum_mode(no_checksum_mode)
                 .with_clients(clients)
                 .build()
                 .await?
@@ -430,7 +453,7 @@ impl Check {
     pub async fn check(
         self,
         optimization: Optimization,
-        credentials: &Credentials,
+        compatibility: &Compatibility,
         write_sums_file: bool,
         verify: bool,
         clients: Vec<Arc<Client>>,
@@ -440,7 +463,8 @@ impl Check {
 
         let mut builder = CheckTaskBuilder::default()
             .with_group_by(group_by)
-            .with_avoid_get_object_attributes(credentials.avoid_get_object_attributes)
+            .with_no_get_object_attributes(compatibility.no_get_object_attributes())
+            .with_no_checksum_mode(compatibility.no_checksum_mode())
             .with_input_files(self.input.clone())
             .with_update(self.update)
             .with_clients(clients.clone());
@@ -449,7 +473,8 @@ impl Check {
             let (ctxs, _) = Check::comparable_check(
                 self.input.clone(),
                 clients.clone(),
-                credentials.avoid_get_object_attributes,
+                compatibility.no_get_object_attributes(),
+                compatibility.no_checksum_mode(),
             )
             .await?;
             let checksum = Check::generate_sums(ctxs);
@@ -461,7 +486,7 @@ impl Check {
                 force_overwrite: false,
                 verify,
             }
-            .generate(optimization, credentials, clients.clone(), write_sums_file)
+            .generate(optimization, compatibility, clients.clone(), write_sums_file)
             .await
             .map_err(|stats| CheckStats::from_generate_task(group_by, *stats))?;
             let sums = stats
@@ -643,7 +668,7 @@ impl Copy {
         source_client: Arc<Client>,
         destination_client: Arc<Client>,
         optimization: Optimization,
-        credentials: &Credentials,
+        compatibility: &Compatibility,
         verify: bool,
         write_sums_file: bool,
     ) -> stats::Result<CheckStats> {
@@ -657,7 +682,7 @@ impl Copy {
         }
         .check(
             optimization,
-            credentials,
+            compatibility,
             write_sums_file,
             verify,
             vec![source_client, destination_client],
@@ -673,6 +698,7 @@ impl Copy {
         source_client: Arc<Client>,
         destination_client: Arc<Client>,
         credentials: Credentials,
+        compatibility: Compatibility,
         optimization: Optimization,
         write_sums_file: bool,
         ui: bool,
@@ -687,8 +713,9 @@ impl Copy {
 
             // Check if it exists in the first place.
             let file_size = ObjectSumsBuilder::default()
-                .set_client(Some(source_client.clone()))
-                .with_avoid_get_object_attributes(credentials.avoid_get_object_attributes)
+                .set_client(Some(destination_client.clone()))
+                .with_no_get_object_attributes(compatibility.no_get_object_attributes())
+                .with_no_checksum_mode(compatibility.no_checksum_mode())
                 .build(self.destination.to_string())
                 .await?
                 .file_size()
@@ -704,7 +731,7 @@ impl Copy {
                         source_client.clone(),
                         destination_client.clone(),
                         optimization.clone(),
-                        &credentials,
+                        &compatibility,
                         false,
                         write_sums_file,
                     )
@@ -779,7 +806,8 @@ impl Copy {
             .with_metadata_mode(self.metadata_mode)
             .with_tag_mode(self.tag_mode)
             .with_multipart_threshold(self.multipart_threshold)
-            .with_avoid_get_object_attributes(credentials.avoid_get_object_attributes)
+            .with_no_get_object_attributes(compatibility.no_get_object_attributes())
+            .with_no_checksum_mode(compatibility.no_checksum_mode())
             .with_concurrency(self.concurrency)
             .with_part_size(self.part_size)
             .with_ui(ui)
@@ -803,7 +831,7 @@ impl Copy {
                     source_client,
                     destination_client,
                     optimization,
-                    &credentials,
+                    &compatibility,
                     sums_mismatch,
                     write_sums_file,
                 )
@@ -959,6 +987,79 @@ pub struct Output {
     pub write_sums_file: bool,
 }
 
+/// Options related to increasing compatibility with S3-compatible storage. These options are
+/// useful when using an S3-compatible endpoint that does not support all S3 features.
+#[derive(Args, Debug, Clone)]
+#[group(required = false)]
+#[command(next_help_heading = "Compatibility")]
+pub struct Compatibility {
+    /// Enable all compatibility options.
+    ///
+    /// This is a convenience flag that enables `--force-path-style`,
+    /// `--no-get-object-attributes`, and `--no-checksum-mode`.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_S3_COMPATIBLE",
+        hide_short_help = true
+    )]
+    pub s3_compatible: bool,
+    /// Use path-style addressing for S3 endpoints.
+    ///
+    /// By default, the S3 client uses virtual-hosted-style addressing. Some S3-compatible
+    /// endpoints such as Ceph require path-style addressing instead.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_FORCE_PATH_STYLE",
+        hide_short_help = true
+    )]
+    pub force_path_style: bool,
+    /// Do not use `GetObjectAttributes` calls when determining sums.
+    ///
+    /// `HeadObject` will be used as a fallback. This is an option because some S3-compatible
+    /// endpoints do not support `GetObjectAttributes`. If available, `GetObjectAttributes` is
+    /// preferred over `HeadObject` because it only requires a single call rather than a call for
+    /// each part.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_NO_GET_OBJECT_ATTRIBUTES",
+        hide_short_help = true
+    )]
+    pub no_get_object_attributes: bool,
+    /// Do not use `ChecksumMode::Enabled` on `HeadObject` calls.
+    ///
+    /// Some S3-compatible endpoints such as Ceph do not support the additional checksums on API
+    /// calls like `HeadObject`, which this option disables. This will also force `copyrite` to
+    /// only use `ETag`s for verification, and not additional checksums.
+    /// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_NO_CHECKSUM_MODE",
+        hide_short_help = true
+    )]
+    pub no_checksum_mode: bool,
+}
+
+impl Compatibility {
+    /// Whether to force path-style addressing.
+    pub fn force_path_style(&self) -> bool {
+        self.s3_compatible || self.force_path_style
+    }
+
+    /// Whether to avoid `GetObjectAttributes` calls.
+    pub fn no_get_object_attributes(&self) -> bool {
+        self.s3_compatible || self.no_get_object_attributes
+    }
+
+    /// Whether to disable checksum mode.
+    pub fn no_checksum_mode(&self) -> bool {
+        self.s3_compatible || self.no_checksum_mode
+    }
+}
+
 /// Options related to credentials. Options prefixed with `source_` affect `check`, `generate` and
 /// the source of a `copy` command. These options also have an alias without the prefix as they are
 /// used in all commands. Options prefixed with `destination_` only affect the destination of a
@@ -1077,19 +1178,6 @@ pub struct Credentials {
         hide_short_help = true
     )]
     pub destination_endpoint_url: Option<String>,
-    /// Avoid `GetObjectAttributes` calls when determining sums.
-    ///
-    /// `HeadObject` will be used as a fallback. This is an option because some S3-compatible
-    /// endpoints do not support `GetObjectAttributes`. If available, `GetObjectAttributes` is
-    /// preferred over `HeadObject` because it only requires a single call rather than a call for
-    /// each part.
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_AVOID_GET_OBJECT_ATTRIBUTES",
-        hide_short_help = true
-    )]
-    pub avoid_get_object_attributes: bool,
     /// The source AWS access key ID. Overrides the value from the selected credential provider.
     #[arg(
         global = true,
@@ -1149,7 +1237,7 @@ pub struct Credentials {
 
 impl Credentials {
     /// Construct the source client from the credentials.
-    pub async fn source_client(&self) -> Result<Client> {
+    pub async fn source_client(&self, compatibility: &Compatibility) -> Result<Client> {
         let overrides = CredentialOverrides::new(
             self.source_access_key_id.clone(),
             self.source_secret_access_key.clone(),
@@ -1162,12 +1250,13 @@ impl Credentials {
             self.source_endpoint_url.as_deref(),
             self.source_secret.as_deref(),
             overrides,
+            compatibility.force_path_style(),
         )
         .await
     }
 
     /// Construct the destination client from the credentials.
-    pub async fn destination_client(&self) -> Result<Client> {
+    pub async fn destination_client(&self, compatibility: &Compatibility) -> Result<Client> {
         let overrides = CredentialOverrides::new(
             self.destination_access_key_id.clone(),
             self.destination_secret_access_key.clone(),
@@ -1180,6 +1269,7 @@ impl Credentials {
             self.destination_endpoint_url.as_deref(),
             self.destination_secret.as_deref(),
             overrides,
+            compatibility.force_path_style(),
         )
         .await
     }

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -112,9 +112,7 @@ impl Command {
     /// Execute the command from the args.
     pub async fn execute(self) -> Result<()> {
         let now = Instant::now();
-        let client = self.credentials
-            .source_client(&self.compatibility)
-            .await?;
+        let client = self.credentials.source_client(&self.compatibility).await?;
 
         let pretty_json = self.output.pretty_json;
         let write_sums_file = self.output.write_sums_file;
@@ -123,11 +121,7 @@ impl Command {
         match self.commands {
             Subcommands::Generate(generate_args) => {
                 let stats = generate_args
-                    .generate(
-                        self.optimization,
-                        vec![client],
-                        true,
-                    )
+                    .generate(self.optimization, vec![client], true)
                     .await
                     .map_err(|err| Box::new(err.with_elapsed(now.elapsed())))?;
                 if let Some(sums) = stats.sums {
@@ -139,19 +133,15 @@ impl Command {
             }
             Subcommands::Check(check_args) => {
                 let output = check_args
-                    .check(
-                        self.optimization,
-                        write_sums_file,
-                        false,
-                        vec![client],
-                    )
+                    .check(self.optimization, write_sums_file, false, vec![client])
                     .await
                     .map_err(|err| Box::new(err.with_elapsed(now.elapsed())))?;
 
                 Self::print_stats(&output, pretty_json, ui)?;
             }
             Subcommands::Copy(copy_args) => {
-                let destination_client = self.credentials
+                let destination_client = self
+                    .credentials
                     .destination_client(&self.compatibility)
                     .await?;
 
@@ -293,11 +283,8 @@ impl Generate {
 
             if self.missing {
                 let now = Instant::now();
-                let (ctxs, group_by) = Check::comparable_check(
-                    self.input.clone(),
-                    clients.clone(),
-                )
-                .await?;
+                let (ctxs, group_by) =
+                    Check::comparable_check(self.input.clone(), clients.clone()).await?;
                 let (objects, compared, updated, api_errors) = ctxs.into_inner();
                 check_stats = Some(
                     CheckStats::new(
@@ -450,11 +437,7 @@ impl Check {
             .with_clients(clients.clone());
         let mut generate_stats = None;
         if self.missing {
-            let (ctxs, _) = Check::comparable_check(
-                self.input.clone(),
-                clients.clone(),
-            )
-            .await?;
+            let (ctxs, _) = Check::comparable_check(self.input.clone(), clients.clone()).await?;
             let checksum = Check::generate_sums(ctxs);
 
             let mut stats = Generate {
@@ -1019,21 +1002,61 @@ pub struct Compatibility {
         hide_short_help = true
     )]
     pub no_checksum_mode: bool,
-    #[arg(global = true, long, env = "COPYRITE_SOURCE_S3_COMPATIBLE", hide = true)]
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_SOURCE_S3_COMPATIBLE",
+        hide = true
+    )]
     pub source_s3_compatible: bool,
-    #[arg(global = true, long, env = "COPYRITE_SOURCE_FORCE_PATH_STYLE", hide = true)]
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_SOURCE_FORCE_PATH_STYLE",
+        hide = true
+    )]
     pub source_force_path_style: bool,
-    #[arg(global = true, long, env = "COPYRITE_SOURCE_NO_GET_OBJECT_ATTRIBUTES", hide = true)]
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_SOURCE_NO_GET_OBJECT_ATTRIBUTES",
+        hide = true
+    )]
     pub source_no_get_object_attributes: bool,
-    #[arg(global = true, long, env = "COPYRITE_SOURCE_NO_CHECKSUM_MODE", hide = true)]
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_SOURCE_NO_CHECKSUM_MODE",
+        hide = true
+    )]
     pub source_no_checksum_mode: bool,
-    #[arg(global = true, long, env = "COPYRITE_DESTINATION_S3_COMPATIBLE", hide = true)]
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_DESTINATION_S3_COMPATIBLE",
+        hide = true
+    )]
     pub destination_s3_compatible: bool,
-    #[arg(global = true, long, env = "COPYRITE_DESTINATION_FORCE_PATH_STYLE", hide = true)]
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_DESTINATION_FORCE_PATH_STYLE",
+        hide = true
+    )]
     pub destination_force_path_style: bool,
-    #[arg(global = true, long, env = "COPYRITE_DESTINATION_NO_GET_OBJECT_ATTRIBUTES", hide = true)]
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_DESTINATION_NO_GET_OBJECT_ATTRIBUTES",
+        hide = true
+    )]
     pub destination_no_get_object_attributes: bool,
-    #[arg(global = true, long, env = "COPYRITE_DESTINATION_NO_CHECKSUM_MODE", hide = true)]
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_DESTINATION_NO_CHECKSUM_MODE",
+        hide = true
+    )]
     pub destination_no_checksum_mode: bool,
 }
 
@@ -1055,9 +1078,7 @@ impl Compatibility {
 
     /// Whether to force path-style addressing for the source.
     pub fn source_force_path_style(&self) -> bool {
-        self.source_s3_compatible
-            || self.source_force_path_style
-            || self.force_path_style()
+        self.source_s3_compatible || self.source_force_path_style || self.force_path_style()
     }
 
     /// Whether to force path-style addressing for the destination.
@@ -1083,9 +1104,7 @@ impl Compatibility {
 
     /// Whether to disable checksum mode for the source.
     pub fn source_no_checksum_mode(&self) -> bool {
-        self.source_s3_compatible
-            || self.source_no_checksum_mode
-            || self.no_checksum_mode()
+        self.source_s3_compatible || self.source_no_checksum_mode || self.no_checksum_mode()
     }
 
     /// Whether to disable checksum mode for the destination.
@@ -1106,7 +1125,6 @@ impl Compatibility {
             || self.destination_no_get_object_attributes
             || self.destination_no_checksum_mode
     }
-
 }
 
 /// Options related to credentials. Unprefixed options apply to both source and destination. For
@@ -1134,13 +1152,7 @@ pub struct Credentials {
     )]
     pub credential_provider: Option<CredentialProvider>,
     /// The profile to use if the credential provider is `aws-profile`.
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_PROFILE",
-
-        hide_short_help = true
-    )]
+    #[arg(global = true, long, env = "COPYRITE_PROFILE", hide_short_help = true)]
     pub profile: Option<String>,
     /// The secret name or ARN to use if the credential provider is `aws-secret`.
     ///
@@ -1160,19 +1172,12 @@ pub struct Credentials {
         global = true,
         long,
         env = "COPYRITE_SECRET",
-
         hide_short_help = true,
         verbatim_doc_comment
     )]
     pub secret: Option<String>,
     /// Set the region for the credential provider.
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_REGION",
-
-        hide_short_help = true
-    )]
+    #[arg(global = true, long, env = "COPYRITE_REGION", hide_short_help = true)]
     pub region: Option<String>,
     /// Set the endpoint URL for AWS calls. This allows using a different endpoint that has an
     /// S3-compatible storage API.
@@ -1180,7 +1185,6 @@ pub struct Credentials {
         global = true,
         long,
         env = "COPYRITE_ENDPOINT_URL",
-
         hide_short_help = true
     )]
     pub endpoint_url: Option<String>,
@@ -1189,7 +1193,6 @@ pub struct Credentials {
         global = true,
         long,
         env = "COPYRITE_ACCESS_KEY_ID",
-
         hide_short_help = true
     )]
     pub access_key_id: Option<String>,
@@ -1198,7 +1201,6 @@ pub struct Credentials {
         global = true,
         long,
         env = "COPYRITE_SECRET_ACCESS_KEY",
-
         hide_short_help = true
     )]
     pub secret_access_key: Option<String>,
@@ -1207,7 +1209,6 @@ pub struct Credentials {
         global = true,
         long,
         env = "COPYRITE_SESSION_TOKEN",
-
         hide_short_help = true
     )]
     pub session_token: Option<String>,
@@ -1220,33 +1221,13 @@ pub struct Credentials {
         hide = true
     )]
     pub source_credential_provider: Option<CredentialProvider>,
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_SOURCE_PROFILE",
-        hide = true
-    )]
+    #[arg(global = true, long, env = "COPYRITE_SOURCE_PROFILE", hide = true)]
     pub source_profile: Option<String>,
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_SOURCE_SECRET",
-        hide = true
-    )]
+    #[arg(global = true, long, env = "COPYRITE_SOURCE_SECRET", hide = true)]
     pub source_secret: Option<String>,
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_SOURCE_REGION",
-        hide = true
-    )]
+    #[arg(global = true, long, env = "COPYRITE_SOURCE_REGION", hide = true)]
     pub source_region: Option<String>,
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_SOURCE_ENDPOINT_URL",
-        hide = true
-    )]
+    #[arg(global = true, long, env = "COPYRITE_SOURCE_ENDPOINT_URL", hide = true)]
     pub source_endpoint_url: Option<String>,
     #[arg(
         global = true,
@@ -1278,26 +1259,11 @@ pub struct Credentials {
         hide = true
     )]
     pub destination_credential_provider: Option<CredentialProvider>,
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_DESTINATION_PROFILE",
-        hide = true
-    )]
+    #[arg(global = true, long, env = "COPYRITE_DESTINATION_PROFILE", hide = true)]
     pub destination_profile: Option<String>,
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_DESTINATION_SECRET",
-        hide = true
-    )]
+    #[arg(global = true, long, env = "COPYRITE_DESTINATION_SECRET", hide = true)]
     pub destination_secret: Option<String>,
-    #[arg(
-        global = true,
-        long,
-        env = "COPYRITE_DESTINATION_REGION",
-        hide = true
-    )]
+    #[arg(global = true, long, env = "COPYRITE_DESTINATION_REGION", hide = true)]
     pub destination_region: Option<String>,
     #[arg(
         global = true,
@@ -1346,9 +1312,7 @@ impl Credentials {
 
     /// Resolve the effective source profile.
     pub fn effective_source_profile(&self) -> Option<&str> {
-        self.source_profile
-            .as_deref()
-            .or(self.profile.as_deref())
+        self.source_profile.as_deref().or(self.profile.as_deref())
     }
 
     /// Resolve the effective destination profile.
@@ -1360,9 +1324,7 @@ impl Credentials {
 
     /// Resolve the effective source secret.
     pub fn effective_source_secret(&self) -> Option<&str> {
-        self.source_secret
-            .as_deref()
-            .or(self.secret.as_deref())
+        self.source_secret.as_deref().or(self.secret.as_deref())
     }
 
     /// Resolve the effective destination secret.
@@ -1374,9 +1336,7 @@ impl Credentials {
 
     /// Resolve the effective source region.
     pub fn effective_source_region(&self) -> Option<&str> {
-        self.source_region
-            .as_deref()
-            .or(self.region.as_deref())
+        self.source_region.as_deref().or(self.region.as_deref())
     }
 
     /// Resolve the effective destination region.
@@ -1402,24 +1362,20 @@ impl Credentials {
 
     /// Construct the source client from the credentials.
     pub async fn source_client(&self, compatibility: &Compatibility) -> Result<S3Client> {
-        S3Client::new_from_cli_source(
-            self,
-            compatibility
-        ).await
+        S3Client::new_from_cli_source(self, compatibility).await
     }
 
     /// Construct the destination client from the credentials.
     pub async fn destination_client(&self, compatibility: &Compatibility) -> Result<S3Client> {
-        S3Client::new_from_cli_destination(
-            self,
-            compatibility
-        ).await
+        S3Client::new_from_cli_destination(self, compatibility).await
     }
 
     /// Check if the default credentials are being used without any overrides.
     pub fn is_default(&self) -> bool {
         self.effective_source_credential_provider().is_default()
-            && self.effective_destination_credential_provider().is_default()
+            && self
+                .effective_destination_credential_provider()
+                .is_default()
             && self.effective_source_endpoint_url().is_none()
             && self.effective_destination_endpoint_url().is_none()
             && !self.source_overrides().any()

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -5,8 +5,8 @@ use crate::checksum::file::SumsFile;
 use crate::cli::MetadataCopy;
 use crate::error::Error::{CopyError, ParseError};
 use crate::error::{ApiError, Error, Result};
+use crate::io::S3Client;
 use crate::io::copy::{CopyContent, CopyResult, CopyState, MultiPartOptions, ObjectCopy, Part};
-use aws_sdk_s3::Client;
 use aws_sdk_s3::operation::get_object_tagging::{GetObjectTaggingError, GetObjectTaggingOutput};
 use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
 use aws_sdk_s3::operation::upload_part::UploadPartOutput;
@@ -19,13 +19,12 @@ use aws_smithy_runtime_api::client::result::SdkError;
 use aws_smithy_types::byte_stream::ByteStream;
 use std::collections::HashMap;
 use std::result;
-use std::sync::Arc;
 use tokio::io::AsyncReadExt;
 
 /// Build an S3 sums object.
 #[derive(Debug, Default)]
 pub struct S3Builder {
-    client: Option<Arc<Client>>,
+    client: Option<S3Client>,
     metadata_mode: MetadataCopy,
     tag_mode: MetadataCopy,
     source: Option<BucketKey>,
@@ -34,7 +33,7 @@ pub struct S3Builder {
 
 impl S3Builder {
     /// Set the client.
-    pub fn with_client(mut self, client: Arc<Client>) -> Self {
+    pub fn with_client(mut self, client: S3Client) -> Self {
         self.client = Some(client);
         self
     }
@@ -90,7 +89,7 @@ impl S3Builder {
 
 impl
     From<(
-        Arc<Client>,
+        S3Client,
         MetadataCopy,
         MetadataCopy,
         Option<BucketKey>,
@@ -99,7 +98,7 @@ impl
 {
     fn from(
         (client, metadata_mode, tag_mode, source, destination): (
-            Arc<Client>,
+            S3Client,
             MetadataCopy,
             MetadataCopy,
             Option<BucketKey>,
@@ -172,7 +171,7 @@ pub struct BucketKey {
 /// An S3 object and AWS-related existing sums.
 #[derive(Debug, Clone)]
 pub struct S3 {
-    client: Arc<Client>,
+    client: S3Client,
     metadata_mode: MetadataCopy,
     tag_mode: MetadataCopy,
     source: Option<BucketKey>,
@@ -216,6 +215,7 @@ impl S3 {
         bucket: &str,
     ) -> result::Result<HeadObjectOutput, SdkError<HeadObjectError, HttpResponse>> {
         self.client
+            .inner()
             .head_object()
             .bucket(bucket)
             .key(key)
@@ -230,6 +230,7 @@ impl S3 {
         bucket: &str,
     ) -> result::Result<GetObjectTaggingOutput, SdkError<GetObjectTaggingError, HttpResponse>> {
         self.client
+            .inner()
             .get_object_tagging()
             .bucket(bucket)
             .key(key)
@@ -239,7 +240,7 @@ impl S3 {
 
     /// Create a new S3 object.
     pub fn new(
-        client: Arc<Client>,
+        client: S3Client,
         metadata_mode: MetadataCopy,
         tag_mode: MetadataCopy,
         source: Option<BucketKey>,
@@ -265,6 +266,7 @@ impl S3 {
     ) -> Result<(String, Vec<ApiError>)> {
         let do_upload = |tagging, metadata, additional_checksum| async {
             self.client
+                .inner()
                 .create_multipart_upload()
                 .set_tagging(tagging)
                 .set_metadata(metadata)
@@ -330,6 +332,7 @@ impl S3 {
         let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
         let do_copy = |tagging, tagging_set, metadata, metadata_set, additional_checksum| async {
             self.client
+                .inner()
                 .copy_object()
                 .tagging_directive(tagging)
                 .set_tagging(tagging_set)
@@ -432,6 +435,7 @@ impl S3 {
         if let Some(part_number) = multi_part.part_number {
             let part = self
                 .client
+                .inner()
                 .upload_part_copy()
                 .upload_id(&upload_id)
                 .part_number(i32::try_from(part_number)?)
@@ -478,6 +482,7 @@ impl S3 {
 
         let result = self
             .client
+            .inner()
             .get_object()
             .bucket(&source.bucket)
             .key(&source.key)
@@ -504,6 +509,7 @@ impl S3 {
         let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
         let do_put = |tags, metadata, additional_checksum, buf| async {
             self.client
+                .inner()
                 .put_object()
                 .set_tagging(tags)
                 .set_metadata(metadata)
@@ -590,6 +596,7 @@ impl S3 {
         if let Some(part_number) = multi_part.part_number {
             let part = self
                 .client
+                .inner()
                 .upload_part()
                 .upload_id(&upload_id)
                 .set_checksum_algorithm(additional_checksum)
@@ -630,6 +637,7 @@ impl S3 {
         parts.sort_by(|a, b| a.part_number.cmp(&b.part_number));
 
         self.client
+            .inner()
             .complete_multipart_upload()
             .bucket(bucket)
             .key(key)

--- a/copyrite/src/io/copy/mod.rs
+++ b/copyrite/src/io/copy/mod.rs
@@ -10,7 +10,6 @@ use crate::io::copy::file::FileBuilder;
 use crate::io::{Provider, S3Client};
 use dyn_clone::DynClone;
 use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::io::{AsyncRead, empty};
 
 pub mod aws;
@@ -217,10 +216,9 @@ impl ObjectCopyBuilder {
         };
 
         if is_s3 {
-            let client = match self.client {
-                Some(client) => client,
-                None => S3Client::new(Arc::new(S3Client::default_s3_client().await?), false, false),
-            };
+            let client = self.client.ok_or_else(|| {
+                CopyError("an S3 client is required for S3 providers".to_string())
+            })?;
             let source = self.source.map(|source| source.into_s3()).transpose()?;
             let destination = self
                 .destination

--- a/copyrite/src/io/copy/mod.rs
+++ b/copyrite/src/io/copy/mod.rs
@@ -7,8 +7,7 @@ use crate::error::Error::CopyError;
 use crate::error::{ApiError, Result};
 use crate::io::copy::aws::S3Builder;
 use crate::io::copy::file::FileBuilder;
-use crate::io::{Provider, default_s3_client};
-use aws_sdk_s3::Client;
+use crate::io::{Provider, S3Client};
 use dyn_clone::DynClone;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -203,7 +202,7 @@ dyn_clone::clone_trait_object!(ObjectCopy);
 pub struct ObjectCopyBuilder {
     metadata_mode: MetadataCopy,
     tag_mode: MetadataCopy,
-    client: Option<Arc<Client>>,
+    client: Option<S3Client>,
     source: Option<Provider>,
     destination: Option<Provider>,
 }
@@ -220,7 +219,7 @@ impl ObjectCopyBuilder {
         if is_s3 {
             let client = match self.client {
                 Some(client) => client,
-                None => Arc::new(default_s3_client().await?),
+                None => S3Client::new(Arc::new(S3Client::default_s3_client().await?), false, false),
             };
             let source = self.source.map(|source| source.into_s3()).transpose()?;
             let destination = self
@@ -279,7 +278,7 @@ impl ObjectCopyBuilder {
     }
 
     /// Set the S3 client if this is an s3 provider.
-    pub fn set_client(mut self, client: Option<Arc<Client>>) -> Self {
+    pub fn set_client(mut self, client: Option<S3Client>) -> Self {
         self.client = client;
         self
     }

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -1,7 +1,7 @@
 //! Module that handles all file IO
 //!
 
-use crate::cli::{Credentials, CredentialProvider, Compatibility};
+use crate::cli::{Compatibility, CredentialProvider, Credentials};
 use crate::error::Error::ParseError;
 use crate::error::{Error, Result};
 use aws_config::Region;
@@ -39,7 +39,7 @@ impl S3Client {
     /// Create a new source S3Client from CLI compatibility and credentials options.
     pub async fn new_from_cli_source(
         credentials: &Credentials,
-        compatibility: &Compatibility
+        compatibility: &Compatibility,
     ) -> Result<Self> {
         let client = Self::create_s3_client(
             &credentials.effective_source_credential_provider(),
@@ -50,7 +50,7 @@ impl S3Client {
             credentials.source_overrides(),
             compatibility.source_force_path_style(),
         )
-            .await?;
+        .await?;
         Ok(Self::new(
             Arc::new(client),
             compatibility.source_no_get_object_attributes(),
@@ -61,7 +61,7 @@ impl S3Client {
     /// Create a new source S3Client from CLI compatibility and credentials options.
     pub async fn new_from_cli_destination(
         credentials: &Credentials,
-        compatibility: &Compatibility
+        compatibility: &Compatibility,
     ) -> Result<Self> {
         let client = Self::create_s3_client(
             &credentials.effective_destination_credential_provider(),
@@ -72,7 +72,7 @@ impl S3Client {
             credentials.destination_overrides(),
             compatibility.destination_force_path_style(),
         )
-            .await?;
+        .await?;
         Ok(Self::new(
             Arc::new(client),
             compatibility.destination_no_get_object_attributes(),
@@ -127,7 +127,8 @@ impl S3Client {
             }
             (CredentialProvider::AwsProfile, None, _) => {
                 return Err(ParseError(
-                    "profile must be specified if using aws-profile credential provider".to_string(),
+                    "profile must be specified if using aws-profile credential provider"
+                        .to_string(),
                 ));
             }
             (CredentialProvider::AwsSecret, _, None) => {
@@ -177,7 +178,7 @@ impl S3Client {
             no_overrides,
             false,
         )
-            .await
+        .await
     }
 }
 
@@ -383,7 +384,10 @@ impl CredentialOverrides {
 
     /// Merge overrides with base credentials. Each override takes precedence over the corresponding
     /// field in the base credentials.
-    pub fn merge_with(&self, base: Option<&aws_credential_types::Credentials>) -> Result<aws_credential_types::Credentials> {
+    pub fn merge_with(
+        &self,
+        base: Option<&aws_credential_types::Credentials>,
+    ) -> Result<aws_credential_types::Credentials> {
         let access_key_id = self
             .access_key_id
             .as_deref()

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -1,18 +1,185 @@
 //! Module that handles all file IO
 //!
 
-use crate::cli::CredentialProvider;
+use crate::cli::{Credentials, CredentialProvider, Compatibility};
 use crate::error::Error::ParseError;
 use crate::error::{Error, Result};
 use aws_config::Region;
-use aws_credential_types::Credentials;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_sdk_s3::{Client, config};
 use aws_smithy_runtime_api::client::behavior_version::BehaviorVersion;
 use serde::Deserialize;
+use std::sync::Arc;
 
 pub mod copy;
 pub mod sums;
+
+/// An S3 client wrapper with compatibility settings.
+#[derive(Debug, Clone)]
+pub struct S3Client {
+    inner: Arc<Client>,
+    no_get_object_attributes: bool,
+    no_checksum_mode: bool,
+}
+
+impl S3Client {
+    /// Create a new S3Client.
+    pub fn new(
+        client: Arc<Client>,
+        no_get_object_attributes: bool,
+        no_checksum_mode: bool,
+    ) -> Self {
+        Self {
+            inner: client,
+            no_get_object_attributes,
+            no_checksum_mode,
+        }
+    }
+
+    /// Create a new source S3Client from CLI compatibility and credentials options.
+    pub async fn new_from_cli_source(
+        credentials: &Credentials,
+        compatibility: &Compatibility
+    ) -> Result<Self> {
+        let client = Self::create_s3_client(
+            &credentials.effective_source_credential_provider(),
+            credentials.effective_source_profile(),
+            credentials.effective_source_region(),
+            credentials.effective_source_endpoint_url(),
+            credentials.effective_source_secret(),
+            credentials.source_overrides(),
+            compatibility.source_force_path_style(),
+        )
+            .await?;
+        Ok(Self::new(
+            Arc::new(client),
+            compatibility.source_no_get_object_attributes(),
+            compatibility.source_no_checksum_mode(),
+        ))
+    }
+
+    /// Create a new source S3Client from CLI compatibility and credentials options.
+    pub async fn new_from_cli_destination(
+        credentials: &Credentials,
+        compatibility: &Compatibility
+    ) -> Result<Self> {
+        let client = Self::create_s3_client(
+            &credentials.effective_destination_credential_provider(),
+            credentials.effective_destination_profile(),
+            credentials.effective_destination_region(),
+            credentials.effective_destination_endpoint_url(),
+            credentials.effective_destination_secret(),
+            credentials.destination_overrides(),
+            compatibility.destination_force_path_style(),
+        )
+            .await?;
+        Ok(Self::new(
+            Arc::new(client),
+            compatibility.destination_no_get_object_attributes(),
+            compatibility.destination_no_checksum_mode(),
+        ))
+    }
+
+    /// Get the inner AWS S3 client.
+    pub fn inner(&self) -> &Arc<Client> {
+        &self.inner
+    }
+
+    /// Whether to avoid `GetObjectAttributes` calls.
+    pub fn no_get_object_attributes(&self) -> bool {
+        self.no_get_object_attributes
+    }
+
+    /// Whether to disable checksum mode.
+    pub fn no_checksum_mode(&self) -> bool {
+        self.no_checksum_mode
+    }
+
+    /// Create an S3 client from the credentials provider, profile, region and endpoint url.
+    /// Any fields set in `overrides` take precedence over the resolved credential provider values.
+    pub async fn create_s3_client(
+        provider: &CredentialProvider,
+        profile: Option<&str>,
+        region: Option<&str>,
+        endpoint_url: Option<&str>,
+        secret: Option<&str>,
+        overrides: CredentialOverrides,
+        force_path_style: bool,
+    ) -> Result<Client> {
+        let mut loader = aws_config::defaults(BehaviorVersion::latest());
+
+        if let Some(region) = region {
+            loader = loader.region(Region::new(region.to_string()));
+        }
+        if let Some(endpoint_url) = endpoint_url {
+            loader = loader.endpoint_url(endpoint_url);
+        }
+
+        let loader = match (provider, profile, secret) {
+            (CredentialProvider::DefaultEnvironment, _, _) => loader,
+            (CredentialProvider::NoCredentials, _, _) => loader.no_credentials(),
+            (CredentialProvider::AwsProfile, Some(profile), _) => loader.profile_name(profile),
+            (CredentialProvider::AwsSecret, _, Some(secret)) => {
+                let credentials = SecretsManagerCredentials::new(secret)
+                    .await?
+                    .into_credentials();
+                loader.credentials_provider(credentials)
+            }
+            (CredentialProvider::AwsProfile, None, _) => {
+                return Err(ParseError(
+                    "profile must be specified if using aws-profile credential provider".to_string(),
+                ));
+            }
+            (CredentialProvider::AwsSecret, _, None) => {
+                return Err(ParseError(
+                    "secret must be specified if using aws-secret credential provider".to_string(),
+                ));
+            }
+        };
+
+        let sdk_config = loader.load().await;
+
+        let s3_config = if overrides.any() {
+            // Allow no credentials to be set with only overrides.
+            let base = if let Some(creds_provider) = sdk_config.credentials_provider() {
+                creds_provider.provide_credentials().await.ok()
+            } else {
+                None
+            };
+
+            let merged = overrides.merge_with(base.as_ref())?;
+            config::Builder::from(&sdk_config)
+                .credentials_provider(merged)
+                .force_path_style(force_path_style)
+                .build()
+        } else {
+            config::Builder::from(&sdk_config)
+                .force_path_style(force_path_style)
+                .build()
+        };
+
+        Ok(Client::from_conf(s3_config))
+    }
+
+    /// Create the default S3 client.
+    pub async fn default_s3_client() -> Result<Client> {
+        let no_overrides = CredentialOverrides {
+            access_key_id: None,
+            secret_access_key: None,
+            session_token: None,
+        };
+        Self::create_s3_client(
+            &CredentialProvider::DefaultEnvironment,
+            None,
+            None,
+            None,
+            None,
+            no_overrides,
+            false,
+        )
+            .await
+    }
+}
 
 /// The type of provider for the object.
 #[derive(Debug, Clone)]
@@ -114,8 +281,8 @@ fn construct_credentials(
     access_key_id: impl Into<String>,
     secret_access_key: impl Into<String>,
     session_token: Option<impl Into<String>>,
-) -> Credentials {
-    let mut builder = Credentials::builder()
+) -> aws_credential_types::Credentials {
+    let mut builder = aws_credential_types::Credentials::builder()
         .access_key_id(access_key_id)
         .secret_access_key(secret_access_key)
         .provider_name("copyrite");
@@ -177,7 +344,7 @@ impl SecretsManagerCredentials {
     }
 
     /// Convert into AWS config compatible credentials.
-    pub fn into_credentials(self) -> Credentials {
+    pub fn into_credentials(self) -> aws_credential_types::Credentials {
         construct_credentials(
             self.access_key_id,
             self.secret_access_key,
@@ -216,7 +383,7 @@ impl CredentialOverrides {
 
     /// Merge overrides with base credentials. Each override takes precedence over the corresponding
     /// field in the base credentials.
-    pub fn merge_with(&self, base: Option<&Credentials>) -> Result<Credentials> {
+    pub fn merge_with(&self, base: Option<&aws_credential_types::Credentials>) -> Result<aws_credential_types::Credentials> {
         let access_key_id = self
             .access_key_id
             .as_deref()
@@ -247,91 +414,6 @@ impl CredentialOverrides {
             session_token,
         ))
     }
-}
-
-/// Create an S3 client from the credentials provider, profile, region and endpoint url.
-/// Any fields set in `overrides` take precedence over the resolved credential provider values.
-pub async fn create_s3_client(
-    provider: &CredentialProvider,
-    profile: Option<&str>,
-    region: Option<&str>,
-    endpoint_url: Option<&str>,
-    secret: Option<&str>,
-    overrides: CredentialOverrides,
-    force_path_style: bool,
-) -> Result<Client> {
-    let mut loader = aws_config::defaults(BehaviorVersion::latest());
-
-    if let Some(region) = region {
-        loader = loader.region(Region::new(region.to_string()));
-    }
-    if let Some(endpoint_url) = endpoint_url {
-        loader = loader.endpoint_url(endpoint_url);
-    }
-
-    let loader = match (provider, profile, secret) {
-        (CredentialProvider::DefaultEnvironment, _, _) => loader,
-        (CredentialProvider::NoCredentials, _, _) => loader.no_credentials(),
-        (CredentialProvider::AwsProfile, Some(profile), _) => loader.profile_name(profile),
-        (CredentialProvider::AwsSecret, _, Some(secret)) => {
-            let credentials = SecretsManagerCredentials::new(secret)
-                .await?
-                .into_credentials();
-            loader.credentials_provider(credentials)
-        }
-        (CredentialProvider::AwsProfile, None, _) => {
-            return Err(ParseError(
-                "profile must be specified if using aws-profile credential provider".to_string(),
-            ));
-        }
-        (CredentialProvider::AwsSecret, _, None) => {
-            return Err(ParseError(
-                "secret must be specified if using aws-secret credential provider".to_string(),
-            ));
-        }
-    };
-
-    let sdk_config = loader.load().await;
-
-    let s3_config = if overrides.any() {
-        // Allow no credentials to be set with only overrides.
-        let base = if let Some(creds_provider) = sdk_config.credentials_provider() {
-            creds_provider.provide_credentials().await.ok()
-        } else {
-            None
-        };
-
-        let merged = overrides.merge_with(base.as_ref())?;
-        config::Builder::from(&sdk_config)
-            .credentials_provider(merged)
-            .force_path_style(force_path_style)
-            .build()
-    } else {
-        config::Builder::from(&sdk_config)
-            .force_path_style(force_path_style)
-            .build()
-    };
-
-    Ok(Client::from_conf(s3_config))
-}
-
-/// Create the default S3 client.
-pub async fn default_s3_client() -> Result<Client> {
-    let no_overrides = CredentialOverrides {
-        access_key_id: None,
-        secret_access_key: None,
-        session_token: None,
-    };
-    create_s3_client(
-        &CredentialProvider::DefaultEnvironment,
-        None,
-        None,
-        None,
-        None,
-        no_overrides,
-        false,
-    )
-    .await
 }
 
 #[cfg(test)]

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -258,6 +258,7 @@ pub async fn create_s3_client(
     endpoint_url: Option<&str>,
     secret: Option<&str>,
     overrides: CredentialOverrides,
+    force_path_style: bool,
 ) -> Result<Client> {
     let mut loader = aws_config::defaults(BehaviorVersion::latest());
 
@@ -303,9 +304,12 @@ pub async fn create_s3_client(
         let merged = overrides.merge_with(base.as_ref())?;
         config::Builder::from(&sdk_config)
             .credentials_provider(merged)
+            .force_path_style(force_path_style)
             .build()
     } else {
-        config::Builder::from(&sdk_config).build()
+        config::Builder::from(&sdk_config)
+            .force_path_style(force_path_style)
+            .build()
     };
 
     Ok(Client::from_conf(s3_config))
@@ -325,6 +329,7 @@ pub async fn default_s3_client() -> Result<Client> {
         None,
         None,
         no_overrides,
+        false,
     )
     .await
 }

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -58,7 +58,7 @@ impl S3Client {
         ))
     }
 
-    /// Create a new source S3Client from CLI compatibility and credentials options.
+    /// Create a new destination S3Client from CLI compatibility and credentials options.
     pub async fn new_from_cli_destination(
         credentials: &Credentials,
         compatibility: &Compatibility,

--- a/copyrite/src/io/sums/aws.rs
+++ b/copyrite/src/io/sums/aws.rs
@@ -9,8 +9,8 @@ use crate::checksum::standard::StandardCtx;
 use crate::error::Error::ParseError;
 use crate::error::{ApiError, Error, Result};
 use crate::io::Provider;
+use crate::io::S3Client;
 use crate::io::sums::ObjectSums;
-use aws_sdk_s3::Client;
 use aws_sdk_s3::operation::get_object::GetObjectError;
 use aws_sdk_s3::operation::get_object_attributes::GetObjectAttributesOutput;
 use aws_sdk_s3::operation::head_object::HeadObjectOutput;
@@ -22,22 +22,19 @@ use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
-use std::sync::Arc;
 use tokio::io::AsyncRead;
 
 /// Build an S3 sums object.
 #[derive(Debug, Default)]
 pub struct S3Builder {
-    client: Option<Arc<Client>>,
+    client: Option<S3Client>,
     bucket: Option<String>,
     key: Option<String>,
-    no_get_object_attributes: bool,
-    no_checksum_mode: bool,
 }
 
 impl S3Builder {
     /// Set the client.
-    pub fn with_client(mut self, client: Arc<Client>) -> Self {
+    pub fn with_client(mut self, client: S3Client) -> Self {
         self.client = Some(client);
         self
     }
@@ -54,19 +51,7 @@ impl S3Builder {
         self
     }
 
-    /// Avoid `GetObjectAttributes` calls.
-    pub fn with_no_get_object_attributes(mut self, no_get_object_attributes: bool) -> Self {
-        self.no_get_object_attributes = no_get_object_attributes;
-        self
-    }
-
-    /// Disable checksum mode on API calls.
-    pub fn with_no_checksum_mode(mut self, no_checksum_mode: bool) -> Self {
-        self.no_checksum_mode = no_checksum_mode;
-        self
-    }
-
-    fn get_components(self) -> Result<(Arc<Client>, String, String, bool, bool)> {
+    fn get_components(self) -> Result<(S3Client, String, String)> {
         let error_fn =
             || ParseError("client, bucket and key are required in `S3Builder`".to_string());
 
@@ -74,8 +59,6 @@ impl S3Builder {
             self.client.ok_or_else(error_fn)?,
             self.bucket.ok_or_else(error_fn)?,
             self.key.ok_or_else(error_fn)?,
-            self.no_get_object_attributes,
-            self.no_checksum_mode,
         ))
     }
 
@@ -85,22 +68,18 @@ impl S3Builder {
     }
 }
 
-impl From<(Arc<Client>, String, String, bool, bool)> for S3 {
+impl From<(S3Client, String, String)> for S3 {
     fn from(
-        (client, bucket, key, no_get_object_attributes, no_checksum_mode): (
-            Arc<Client>,
+        (client, bucket, key): (
+            S3Client,
             String,
             String,
-            bool,
-            bool,
         ),
     ) -> Self {
         Self::new(
             client,
             bucket,
             key,
-            no_get_object_attributes,
-            no_checksum_mode,
         )
     }
 }
@@ -108,24 +87,20 @@ impl From<(Arc<Client>, String, String, bool, bool)> for S3 {
 /// An S3 object and AWS-related existing sums.
 #[derive(Debug, Clone)]
 pub struct S3 {
-    client: Arc<Client>,
+    client: S3Client,
     bucket: String,
     key: String,
     get_object_attributes: Option<GetObjectAttributesOutput>,
     head_object: HashMap<Option<u64>, HeadObjectOutput>,
     api_errors: HashSet<ApiError>,
-    no_get_object_attributes: bool,
-    no_checksum_mode: bool,
 }
 
 impl S3 {
     /// Create a new S3 object.
     pub fn new(
-        client: Arc<Client>,
+        client: S3Client,
         bucket: String,
         key: String,
-        no_get_object_attributes: bool,
-        no_checksum_mode: bool,
     ) -> S3 {
         Self {
             client,
@@ -134,8 +109,6 @@ impl S3 {
             get_object_attributes: None,
             head_object: HashMap::new(),
             api_errors: HashSet::new(),
-            no_get_object_attributes,
-            no_checksum_mode,
         }
     }
 
@@ -143,6 +116,7 @@ impl S3 {
     pub async fn get_existing_sums(&self) -> Result<Option<SumsFile>> {
         match self
             .client
+            .inner()
             .get_object()
             .bucket(&self.bucket)
             .key(SumsFile::format_sums_file(&self.key))
@@ -164,7 +138,7 @@ impl S3 {
     /// Get the `GetObjectAttributes` output for the target file. This caches the result in
     /// memory so that subsequent calls do not repeat the query.
     pub async fn get_object_attributes(&mut self) -> Option<&GetObjectAttributesOutput> {
-        if self.no_get_object_attributes {
+        if self.client.no_get_object_attributes() {
             return None;
         }
 
@@ -174,6 +148,7 @@ impl S3 {
 
         let attributes = self
             .client
+            .inner()
             .get_object_attributes()
             .bucket(&self.bucket)
             .key(SumsFile::format_target_file(&self.key))
@@ -202,11 +177,12 @@ impl S3 {
 
         let mut head = self
             .client
+            .inner()
             .head_object()
             .bucket(&self.bucket)
             .key(SumsFile::format_target_file(&self.key))
             .set_part_number(part_number.map(i32::try_from).transpose()?);
-        if !self.no_checksum_mode {
+        if !self.client.no_checksum_mode() {
             head = head.checksum_mode(ChecksumMode::Enabled);
         }
         let head_object = head.send().await?;
@@ -473,6 +449,7 @@ impl S3 {
     pub async fn object_reader(&self) -> Result<impl AsyncRead + 'static> {
         Ok(Box::new(
             self.client
+                .inner()
                 .get_object()
                 .bucket(&self.bucket)
                 .key(SumsFile::format_target_file(&self.key))
@@ -497,6 +474,7 @@ impl S3 {
     pub async fn put_sums(&self, sums_file: &SumsFile) -> Result<()> {
         let key = SumsFile::format_sums_file(&self.key);
         self.client
+            .inner()
             .put_object()
             .checksum_algorithm(ChecksumAlgorithm::Crc64Nvme)
             .bucket(&self.bucket)
@@ -546,7 +524,9 @@ pub(crate) mod test {
     use crate::checksum::standard::test::EXPECTED_MD5_SUM;
     use crate::task::generate::test::generate_for;
     use crate::test::{TEST_FILE_NAME, TEST_FILE_SIZE};
+    use aws_sdk_s3::Client;
     use aws_sdk_s3::operation::head_object::builders::HeadObjectOutputBuilder;
+    use std::sync::Arc;
     use aws_sdk_s3::types;
     use aws_sdk_s3::types::GetObjectAttributesParts;
     use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
@@ -570,7 +550,7 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_multi_part_with_sha256_different_part_sizes() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(Arc::new(mock_multi_part_with_sha256_different_part_sizes()))
+            .with_client(S3Client::new(Arc::new(mock_multi_part_with_sha256_different_part_sizes()), false, false))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;
@@ -596,7 +576,7 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_multi_part_etag_only_different_part_sizes() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(Arc::new(mock_multi_part_etag_only_different_part_sizes()))
+            .with_client(S3Client::new(Arc::new(mock_multi_part_etag_only_different_part_sizes()), false, false))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;
@@ -619,7 +599,7 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_multi_part_with_sha256() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(Arc::new(mock_multi_part_with_sha256()))
+            .with_client(S3Client::new(Arc::new(mock_multi_part_with_sha256()), false, false))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;
@@ -649,7 +629,7 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_multi_part_etag_only() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(Arc::new(mock_multi_part_etag_only()))
+            .with_client(S3Client::new(Arc::new(mock_multi_part_etag_only()), false, false))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;
@@ -667,7 +647,7 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_single_part_with_sha256() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(Arc::new(mock_single_part_with_sha256()))
+            .with_client(S3Client::new(Arc::new(mock_single_part_with_sha256()), false, false))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;
@@ -685,7 +665,7 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_single_part_etag_only() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(Arc::new(mock_single_part_etag_only()))
+            .with_client(S3Client::new(Arc::new(mock_single_part_etag_only()), false, false))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;

--- a/copyrite/src/io/sums/aws.rs
+++ b/copyrite/src/io/sums/aws.rs
@@ -306,6 +306,24 @@ impl S3 {
             part_sums.push(Some(part_size));
         }
 
+        let file_size = self
+            .head_object(None)
+            .await?
+            .content_length()
+            .map(u64::try_from)
+            .transpose()?;
+        // Some S3-compatible implementations (e.g. Ceph) return the full object size
+        // for each part query instead of the individual part size, unlike the official
+        // S3 implementation. Check if this is occurring and fall-back to computing
+        // based on part number if so.
+        if total_parts > 1
+            && part_sums
+                .iter()
+                .all(|part| *part == file_size)
+        {
+            return Ok(None);
+        }
+
         Ok(Some(part_sums))
     }
 

--- a/copyrite/src/io/sums/aws.rs
+++ b/copyrite/src/io/sums/aws.rs
@@ -31,7 +31,8 @@ pub struct S3Builder {
     client: Option<Arc<Client>>,
     bucket: Option<String>,
     key: Option<String>,
-    avoid_get_object_attributes: bool,
+    no_get_object_attributes: bool,
+    no_checksum_mode: bool,
 }
 
 impl S3Builder {
@@ -54,12 +55,18 @@ impl S3Builder {
     }
 
     /// Avoid `GetObjectAttributes` calls.
-    pub fn with_avoid_get_object_attributes(mut self, avoid_get_object_attributes: bool) -> Self {
-        self.avoid_get_object_attributes = avoid_get_object_attributes;
+    pub fn with_no_get_object_attributes(mut self, no_get_object_attributes: bool) -> Self {
+        self.no_get_object_attributes = no_get_object_attributes;
         self
     }
 
-    fn get_components(self) -> Result<(Arc<Client>, String, String, bool)> {
+    /// Disable checksum mode on API calls.
+    pub fn with_no_checksum_mode(mut self, no_checksum_mode: bool) -> Self {
+        self.no_checksum_mode = no_checksum_mode;
+        self
+    }
+
+    fn get_components(self) -> Result<(Arc<Client>, String, String, bool, bool)> {
         let error_fn =
             || ParseError("client, bucket and key are required in `S3Builder`".to_string());
 
@@ -67,7 +74,8 @@ impl S3Builder {
             self.client.ok_or_else(error_fn)?,
             self.bucket.ok_or_else(error_fn)?,
             self.key.ok_or_else(error_fn)?,
-            self.avoid_get_object_attributes,
+            self.no_get_object_attributes,
+            self.no_checksum_mode,
         ))
     }
 
@@ -77,11 +85,23 @@ impl S3Builder {
     }
 }
 
-impl From<(Arc<Client>, String, String, bool)> for S3 {
+impl From<(Arc<Client>, String, String, bool, bool)> for S3 {
     fn from(
-        (client, bucket, key, avoid_get_object_attributes): (Arc<Client>, String, String, bool),
+        (client, bucket, key, no_get_object_attributes, no_checksum_mode): (
+            Arc<Client>,
+            String,
+            String,
+            bool,
+            bool,
+        ),
     ) -> Self {
-        Self::new(client, bucket, key, avoid_get_object_attributes)
+        Self::new(
+            client,
+            bucket,
+            key,
+            no_get_object_attributes,
+            no_checksum_mode,
+        )
     }
 }
 
@@ -94,7 +114,8 @@ pub struct S3 {
     get_object_attributes: Option<GetObjectAttributesOutput>,
     head_object: HashMap<Option<u64>, HeadObjectOutput>,
     api_errors: HashSet<ApiError>,
-    avoid_get_object_attributes: bool,
+    no_get_object_attributes: bool,
+    no_checksum_mode: bool,
 }
 
 impl S3 {
@@ -103,7 +124,8 @@ impl S3 {
         client: Arc<Client>,
         bucket: String,
         key: String,
-        avoid_get_object_attributes: bool,
+        no_get_object_attributes: bool,
+        no_checksum_mode: bool,
     ) -> S3 {
         Self {
             client,
@@ -112,7 +134,8 @@ impl S3 {
             get_object_attributes: None,
             head_object: HashMap::new(),
             api_errors: HashSet::new(),
-            avoid_get_object_attributes,
+            no_get_object_attributes,
+            no_checksum_mode,
         }
     }
 
@@ -141,7 +164,7 @@ impl S3 {
     /// Get the `GetObjectAttributes` output for the target file. This caches the result in
     /// memory so that subsequent calls do not repeat the query.
     pub async fn get_object_attributes(&mut self) -> Option<&GetObjectAttributesOutput> {
-        if self.avoid_get_object_attributes {
+        if self.no_get_object_attributes {
             return None;
         }
 
@@ -177,15 +200,16 @@ impl S3 {
             return Ok(&self.head_object[&part_number]);
         }
 
-        let head_object = self
+        let mut head = self
             .client
             .head_object()
             .bucket(&self.bucket)
             .key(SumsFile::format_target_file(&self.key))
-            .set_part_number(part_number.map(i32::try_from).transpose()?)
-            .checksum_mode(ChecksumMode::Enabled)
-            .send()
-            .await?;
+            .set_part_number(part_number.map(i32::try_from).transpose()?);
+        if !self.no_checksum_mode {
+            head = head.checksum_mode(ChecksumMode::Enabled);
+        }
+        let head_object = head.send().await?;
 
         Ok(self.head_object.entry(part_number).or_insert(head_object))
     }

--- a/copyrite/src/io/sums/aws.rs
+++ b/copyrite/src/io/sums/aws.rs
@@ -69,18 +69,8 @@ impl S3Builder {
 }
 
 impl From<(S3Client, String, String)> for S3 {
-    fn from(
-        (client, bucket, key): (
-            S3Client,
-            String,
-            String,
-        ),
-    ) -> Self {
-        Self::new(
-            client,
-            bucket,
-            key,
-        )
+    fn from((client, bucket, key): (S3Client, String, String)) -> Self {
+        Self::new(client, bucket, key)
     }
 }
 
@@ -97,11 +87,7 @@ pub struct S3 {
 
 impl S3 {
     /// Create a new S3 object.
-    pub fn new(
-        client: S3Client,
-        bucket: String,
-        key: String,
-    ) -> S3 {
+    pub fn new(client: S3Client, bucket: String, key: String) -> S3 {
         Self {
             client,
             bucket,
@@ -316,11 +302,7 @@ impl S3 {
         // for each part query instead of the individual part size, unlike the official
         // S3 implementation. Check if this is occurring and fall-back to computing
         // based on part number if so.
-        if total_parts > 1
-            && part_sums
-                .iter()
-                .all(|part| *part == file_size)
-        {
+        if total_parts > 1 && part_sums.iter().all(|part| *part == file_size) {
             return Ok(None);
         }
 
@@ -526,10 +508,10 @@ pub(crate) mod test {
     use crate::test::{TEST_FILE_NAME, TEST_FILE_SIZE};
     use aws_sdk_s3::Client;
     use aws_sdk_s3::operation::head_object::builders::HeadObjectOutputBuilder;
-    use std::sync::Arc;
     use aws_sdk_s3::types;
     use aws_sdk_s3::types::GetObjectAttributesParts;
     use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
+    use std::sync::Arc;
 
     const EXPECTED_SHA256_SUM: &str = "Kf+9U8vkMXmrL6YtvZWMDsMLNAq1DOfHheinpLR3Hjk="; // pragma: allowlist secret
 
@@ -550,7 +532,11 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_multi_part_with_sha256_different_part_sizes() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(S3Client::new(Arc::new(mock_multi_part_with_sha256_different_part_sizes()), false, false))
+            .with_client(S3Client::new(
+                Arc::new(mock_multi_part_with_sha256_different_part_sizes()),
+                false,
+                false,
+            ))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;
@@ -576,7 +562,11 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_multi_part_etag_only_different_part_sizes() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(S3Client::new(Arc::new(mock_multi_part_etag_only_different_part_sizes()), false, false))
+            .with_client(S3Client::new(
+                Arc::new(mock_multi_part_etag_only_different_part_sizes()),
+                false,
+                false,
+            ))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;
@@ -599,7 +589,11 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_multi_part_with_sha256() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(S3Client::new(Arc::new(mock_multi_part_with_sha256()), false, false))
+            .with_client(S3Client::new(
+                Arc::new(mock_multi_part_with_sha256()),
+                false,
+                false,
+            ))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;
@@ -629,7 +623,11 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_multi_part_etag_only() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(S3Client::new(Arc::new(mock_multi_part_etag_only()), false, false))
+            .with_client(S3Client::new(
+                Arc::new(mock_multi_part_etag_only()),
+                false,
+                false,
+            ))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;
@@ -647,7 +645,11 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_single_part_with_sha256() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(S3Client::new(Arc::new(mock_single_part_with_sha256()), false, false))
+            .with_client(S3Client::new(
+                Arc::new(mock_single_part_with_sha256()),
+                false,
+                false,
+            ))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;
@@ -665,7 +667,11 @@ pub(crate) mod test {
     #[tokio::test]
     pub async fn test_single_part_etag_only() -> anyhow::Result<()> {
         let mut s3 = S3Builder::default()
-            .with_client(S3Client::new(Arc::new(mock_single_part_etag_only()), false, false))
+            .with_client(S3Client::new(
+                Arc::new(mock_single_part_etag_only()),
+                false,
+                false,
+            ))
             .with_bucket("bucket".to_string())
             .with_key("key".to_string())
             .build()?;

--- a/copyrite/src/io/sums/mod.rs
+++ b/copyrite/src/io/sums/mod.rs
@@ -3,10 +3,10 @@
 
 use crate::checksum::file::SumsFile;
 use crate::error::{ApiError, Result};
+use crate::io::Provider;
 use crate::io::S3Client;
 use crate::io::sums::aws::S3Builder;
 use crate::io::sums::file::FileBuilder;
-use crate::io::Provider;
 use dyn_clone::DynClone;
 use futures_util::Stream;
 use std::collections::HashSet;

--- a/copyrite/src/io/sums/mod.rs
+++ b/copyrite/src/io/sums/mod.rs
@@ -62,7 +62,8 @@ dyn_clone::clone_trait_object!(ObjectSums);
 #[derive(Debug, Default)]
 pub struct ObjectSumsBuilder {
     client: Option<Arc<Client>>,
-    avoid_get_object_attributes: bool,
+    no_get_object_attributes: bool,
+    no_checksum_mode: bool,
 }
 
 impl ObjectSumsBuilder {
@@ -81,7 +82,8 @@ impl ObjectSumsBuilder {
                         .with_key(key)
                         .with_bucket(bucket)
                         .with_client(client)
-                        .with_avoid_get_object_attributes(self.avoid_get_object_attributes)
+                        .with_no_get_object_attributes(self.no_get_object_attributes)
+                        .with_no_checksum_mode(self.no_checksum_mode)
                         .build()?,
                 ))
             }
@@ -95,8 +97,14 @@ impl ObjectSumsBuilder {
     }
 
     /// Avoid `GetObjectAttributes` calls.
-    pub fn with_avoid_get_object_attributes(mut self, avoid_get_object_attributes: bool) -> Self {
-        self.avoid_get_object_attributes = avoid_get_object_attributes;
+    pub fn with_no_get_object_attributes(mut self, no_get_object_attributes: bool) -> Self {
+        self.no_get_object_attributes = no_get_object_attributes;
+        self
+    }
+
+    /// Disable checksums mode on API calls.
+    pub fn with_no_checksum_mode(mut self, no_checksum_mode: bool) -> Self {
+        self.no_checksum_mode = no_checksum_mode;
         self
     }
 }

--- a/copyrite/src/io/sums/mod.rs
+++ b/copyrite/src/io/sums/mod.rs
@@ -71,10 +71,11 @@ impl ObjectSumsBuilder {
                 Ok(Box::new(FileBuilder::default().with_file(file).build()?))
             }
             Provider::S3 { bucket, key } => {
-                let client = match self.client {
-                    Some(client) => client,
-                    None => S3Client::new(Arc::new(S3Client::default_s3_client().await?), false, false),
-                };
+                let client = self.client.ok_or_else(|| {
+                    crate::error::Error::ParseError(
+                        "an S3 client is required for S3 providers".to_string(),
+                    )
+                })?;
                 Ok(Box::new(
                     S3Builder::default()
                         .with_key(key)

--- a/copyrite/src/io/sums/mod.rs
+++ b/copyrite/src/io/sums/mod.rs
@@ -3,10 +3,10 @@
 
 use crate::checksum::file::SumsFile;
 use crate::error::{ApiError, Result};
+use crate::io::S3Client;
 use crate::io::sums::aws::S3Builder;
 use crate::io::sums::file::FileBuilder;
-use crate::io::{Provider, default_s3_client};
-use aws_sdk_s3::Client;
+use crate::io::Provider;
 use dyn_clone::DynClone;
 use futures_util::Stream;
 use std::collections::HashSet;
@@ -61,9 +61,7 @@ dyn_clone::clone_trait_object!(ObjectSums);
 /// Build object sums from object URLs.
 #[derive(Debug, Default)]
 pub struct ObjectSumsBuilder {
-    client: Option<Arc<Client>>,
-    no_get_object_attributes: bool,
-    no_checksum_mode: bool,
+    client: Option<S3Client>,
 }
 
 impl ObjectSumsBuilder {
@@ -75,15 +73,13 @@ impl ObjectSumsBuilder {
             Provider::S3 { bucket, key } => {
                 let client = match self.client {
                     Some(client) => client,
-                    None => Arc::new(default_s3_client().await?),
+                    None => S3Client::new(Arc::new(S3Client::default_s3_client().await?), false, false),
                 };
                 Ok(Box::new(
                     S3Builder::default()
                         .with_key(key)
                         .with_bucket(bucket)
                         .with_client(client)
-                        .with_no_get_object_attributes(self.no_get_object_attributes)
-                        .with_no_checksum_mode(self.no_checksum_mode)
                         .build()?,
                 ))
             }
@@ -91,20 +87,8 @@ impl ObjectSumsBuilder {
     }
 
     /// Set the S3 client if this is an s3 provider.
-    pub fn set_client(mut self, client: Option<Arc<Client>>) -> Self {
+    pub fn set_client(mut self, client: Option<S3Client>) -> Self {
         self.client = client;
-        self
-    }
-
-    /// Avoid `GetObjectAttributes` calls.
-    pub fn with_no_get_object_attributes(mut self, no_get_object_attributes: bool) -> Self {
-        self.no_get_object_attributes = no_get_object_attributes;
-        self
-    }
-
-    /// Disable checksums mode on API calls.
-    pub fn with_no_checksum_mode(mut self, no_checksum_mode: bool) -> Self {
-        self.no_checksum_mode = no_checksum_mode;
         self
     }
 }

--- a/copyrite/src/task/check.rs
+++ b/copyrite/src/task/check.rs
@@ -4,9 +4,9 @@
 use crate::checksum::Ctx;
 use crate::checksum::file::{Checksum, SumsFile};
 use crate::error::{ApiError, Error, Result};
+use crate::io::S3Client;
 use crate::io::sums::{ObjectSums, ObjectSumsBuilder};
 use crate::stats::{CheckComparison, ChecksumPair};
-use aws_sdk_s3::Client;
 use clap::ValueEnum;
 use futures_util::future::join_all;
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,6 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::sync::Arc;
 use std::{fmt, mem, result};
 
 /// Build a check task.
@@ -24,9 +23,7 @@ pub struct CheckTaskBuilder {
     sums_files: Vec<(String, SumsFile)>,
     group_by: GroupBy,
     update: bool,
-    clients: Vec<Option<Arc<Client>>>,
-    no_get_object_attributes: bool,
-    no_checksum_mode: bool,
+    clients: Vec<Option<S3Client>>,
 }
 
 impl Default for CheckTaskBuilder {
@@ -38,8 +35,6 @@ impl Default for CheckTaskBuilder {
             update: Default::default(),
             // Ensure at least one element in the vector to repeat.
             clients: vec![None],
-            no_get_object_attributes: Default::default(),
-            no_checksum_mode: Default::default(),
         }
     }
 }
@@ -58,7 +53,7 @@ impl CheckTaskBuilder {
     }
 
     /// Set the S3 client to use for each input file.
-    pub fn with_clients(mut self, clients: Vec<Arc<Client>>) -> Self {
+    pub fn with_clients(mut self, clients: Vec<S3Client>) -> Self {
         self.clients = clients.into_iter().map(Some).collect();
         self
     }
@@ -76,20 +71,8 @@ impl CheckTaskBuilder {
     }
 
     /// Set the S3 client to use.
-    pub fn with_client(mut self, client: Arc<Client>) -> Self {
+    pub fn with_client(mut self, client: S3Client) -> Self {
         self.clients = vec![Some(client)];
-        self
-    }
-
-    /// Avoid `GetObjectAttributes` calls.
-    pub fn with_no_get_object_attributes(mut self, no_get_object_attributes: bool) -> Self {
-        self.no_get_object_attributes = no_get_object_attributes;
-        self
-    }
-
-    /// Disable checksum mode on API calls.
-    pub fn with_no_checksum_mode(mut self, no_checksum_mode: bool) -> Self {
-        self.no_checksum_mode = no_checksum_mode;
         self
     }
 
@@ -111,8 +94,6 @@ impl CheckTaskBuilder {
                 .zip(self.clients.into_iter().cycle())
                 .map(|(file, client)| async move {
                     let mut sums = ObjectSumsBuilder::default()
-                        .with_no_get_object_attributes(self.no_get_object_attributes)
-                        .with_no_checksum_mode(self.no_checksum_mode)
                         .set_client(client)
                         .build(file.to_string())
                         .await?;
@@ -157,8 +138,6 @@ impl CheckTaskBuilder {
             objects: CheckObjects(objects),
             group_by,
             update: self.update,
-            no_get_object_attributes: self.no_get_object_attributes,
-            no_checksum_mode: self.no_checksum_mode,
             recoverable_errors: errors,
             ..Default::default()
         })
@@ -213,17 +192,13 @@ impl State {
     pub async fn write_sums_file(
         &self,
         sums: &SumsFile,
-        client: Option<Arc<Client>>,
-        no_get_object_attributes: bool,
-        no_checksum_mode: bool,
+        client: Option<S3Client>,
     ) -> Result<()> {
         match self {
             State::ObjectSums(object) => object.write_sums_file(sums).await,
             State::ExistingSums((location, _)) => {
                 ObjectSumsBuilder::default()
                     .set_client(client)
-                    .with_no_get_object_attributes(no_get_object_attributes)
-                    .with_no_checksum_mode(no_checksum_mode)
                     .build(location.to_string())
                     .await?
                     .write_sums_file(sums)
@@ -356,9 +331,7 @@ pub struct CheckTask {
     update: bool,
     compared_directly: Vec<CheckComparison>,
     updated: Vec<String>,
-    client: Option<Arc<Client>>,
-    no_get_object_attributes: bool,
-    no_checksum_mode: bool,
+    client: Option<S3Client>,
     recoverable_errors: HashSet<ApiError>,
 }
 
@@ -446,8 +419,6 @@ impl CheckTask {
 
     async fn do_check(&mut self) -> Result<()> {
         let update = self.update && matches!(self.group_by, GroupBy::Equality);
-        let no_get_object_attributes = self.no_get_object_attributes;
-        let no_checksum_mode = self.no_checksum_mode;
         let client = self.client.clone();
         match self.group_by {
             GroupBy::Equality => self.merge_same().await,
@@ -467,8 +438,6 @@ impl CheckTask {
                             .write_sums_file(
                                 file,
                                 client.clone(),
-                                no_get_object_attributes,
-                                no_checksum_mode,
                             )
                             .await?;
                         updated_sums.push(location.location());

--- a/copyrite/src/task/check.rs
+++ b/copyrite/src/task/check.rs
@@ -25,7 +25,8 @@ pub struct CheckTaskBuilder {
     group_by: GroupBy,
     update: bool,
     clients: Vec<Option<Arc<Client>>>,
-    avoid_get_object_attributes: bool,
+    no_get_object_attributes: bool,
+    no_checksum_mode: bool,
 }
 
 impl Default for CheckTaskBuilder {
@@ -37,7 +38,8 @@ impl Default for CheckTaskBuilder {
             update: Default::default(),
             // Ensure at least one element in the vector to repeat.
             clients: vec![None],
-            avoid_get_object_attributes: Default::default(),
+            no_get_object_attributes: Default::default(),
+            no_checksum_mode: Default::default(),
         }
     }
 }
@@ -80,8 +82,14 @@ impl CheckTaskBuilder {
     }
 
     /// Avoid `GetObjectAttributes` calls.
-    pub fn with_avoid_get_object_attributes(mut self, avoid_get_object_attributes: bool) -> Self {
-        self.avoid_get_object_attributes = avoid_get_object_attributes;
+    pub fn with_no_get_object_attributes(mut self, no_get_object_attributes: bool) -> Self {
+        self.no_get_object_attributes = no_get_object_attributes;
+        self
+    }
+
+    /// Disable checksum mode on API calls.
+    pub fn with_no_checksum_mode(mut self, no_checksum_mode: bool) -> Self {
+        self.no_checksum_mode = no_checksum_mode;
         self
     }
 
@@ -103,7 +111,8 @@ impl CheckTaskBuilder {
                 .zip(self.clients.into_iter().cycle())
                 .map(|(file, client)| async move {
                     let mut sums = ObjectSumsBuilder::default()
-                        .with_avoid_get_object_attributes(self.avoid_get_object_attributes)
+                        .with_no_get_object_attributes(self.no_get_object_attributes)
+                        .with_no_checksum_mode(self.no_checksum_mode)
                         .set_client(client)
                         .build(file.to_string())
                         .await?;
@@ -148,6 +157,8 @@ impl CheckTaskBuilder {
             objects: CheckObjects(objects),
             group_by,
             update: self.update,
+            no_get_object_attributes: self.no_get_object_attributes,
+            no_checksum_mode: self.no_checksum_mode,
             recoverable_errors: errors,
             ..Default::default()
         })
@@ -203,14 +214,16 @@ impl State {
         &self,
         sums: &SumsFile,
         client: Option<Arc<Client>>,
-        avoid_get_object_attributes: bool,
+        no_get_object_attributes: bool,
+        no_checksum_mode: bool,
     ) -> Result<()> {
         match self {
             State::ObjectSums(object) => object.write_sums_file(sums).await,
             State::ExistingSums((location, _)) => {
                 ObjectSumsBuilder::default()
                     .set_client(client)
-                    .with_avoid_get_object_attributes(avoid_get_object_attributes)
+                    .with_no_get_object_attributes(no_get_object_attributes)
+                    .with_no_checksum_mode(no_checksum_mode)
                     .build(location.to_string())
                     .await?
                     .write_sums_file(sums)
@@ -344,7 +357,8 @@ pub struct CheckTask {
     compared_directly: Vec<CheckComparison>,
     updated: Vec<String>,
     client: Option<Arc<Client>>,
-    avoid_get_object_attributes: bool,
+    no_get_object_attributes: bool,
+    no_checksum_mode: bool,
     recoverable_errors: HashSet<ApiError>,
 }
 
@@ -432,7 +446,8 @@ impl CheckTask {
 
     async fn do_check(&mut self) -> Result<()> {
         let update = self.update && matches!(self.group_by, GroupBy::Equality);
-        let avoid_get_object_attributes = self.avoid_get_object_attributes;
+        let no_get_object_attributes = self.no_get_object_attributes;
+        let no_checksum_mode = self.no_checksum_mode;
         let client = self.client.clone();
         match self.group_by {
             GroupBy::Equality => self.merge_same().await,
@@ -449,7 +464,12 @@ impl CheckTask {
                     self.recoverable_errors.extend(location.api_errors());
                     if current.as_ref() != Some(file) {
                         location
-                            .write_sums_file(file, client.clone(), avoid_get_object_attributes)
+                            .write_sums_file(
+                                file,
+                                client.clone(),
+                                no_get_object_attributes,
+                                no_checksum_mode,
+                            )
                             .await?;
                         updated_sums.push(location.location());
                     }

--- a/copyrite/src/task/check.rs
+++ b/copyrite/src/task/check.rs
@@ -191,11 +191,7 @@ impl State {
 
     /// Write the sums file to the location. If no object sums are used then this creates a new
     /// object sums to write the file.
-    pub async fn write_sums_file(
-        &self,
-        sums: &SumsFile,
-        client: Option<S3Client>,
-    ) -> Result<()> {
+    pub async fn write_sums_file(&self, sums: &SumsFile, client: Option<S3Client>) -> Result<()> {
         match self {
             State::ObjectSums(object) => object.write_sums_file(sums).await,
             State::ExistingSums((location, _)) => {
@@ -436,12 +432,7 @@ impl CheckTask {
 
                     self.recoverable_errors.extend(location.api_errors());
                     if current.as_ref() != Some(file) {
-                        location
-                            .write_sums_file(
-                                file,
-                                client.clone(),
-                            )
-                            .await?;
+                        location.write_sums_file(file, client.clone()).await?;
                         updated_sums.push(location.location());
                     }
                 }

--- a/copyrite/src/task/check.rs
+++ b/copyrite/src/task/check.rs
@@ -88,6 +88,7 @@ impl CheckTaskBuilder {
             .collect::<Vec<_>>();
         self.files.retain(|file| !in_memory.contains(&file));
 
+        let task_client = self.clients.first().cloned().flatten();
         let (objects, errors): (Vec<_>, Vec<_>) = join_all(
             self.files
                 .into_iter()
@@ -139,6 +140,7 @@ impl CheckTaskBuilder {
             group_by,
             update: self.update,
             recoverable_errors: errors,
+            client: task_client,
             ..Default::default()
         })
     }

--- a/copyrite/src/task/copy.rs
+++ b/copyrite/src/task/copy.rs
@@ -37,7 +37,8 @@ pub struct CopyTaskBuilder {
     destination_client: Option<Arc<Client>>,
     concurrency: Option<usize>,
     api_errors: HashSet<ApiError>,
-    avoid_get_object_attributes: bool,
+    no_get_object_attributes: bool,
+    no_checksum_mode: bool,
     ui: bool,
 }
 
@@ -141,8 +142,14 @@ impl CopyTaskBuilder {
     }
 
     /// Avoid `GetObjectAttributes` calls.
-    pub fn with_avoid_get_object_attributes(mut self, avoid_get_object_attributes: bool) -> Self {
-        self.avoid_get_object_attributes = avoid_get_object_attributes;
+    pub fn with_no_get_object_attributes(mut self, no_get_object_attributes: bool) -> Self {
+        self.no_get_object_attributes = no_get_object_attributes;
+        self
+    }
+
+    /// Disable checksum mode on `HeadObject` calls.
+    pub fn with_no_checksum_mode(mut self, no_checksum_mode: bool) -> Self {
+        self.no_checksum_mode = no_checksum_mode;
         self
     }
 
@@ -241,7 +248,8 @@ impl CopyTaskBuilder {
         // Only use the sums file if the size is not set at the source.
         let sums = if self.part_size.is_none() {
             let mut object = ObjectSumsBuilder::default()
-                .with_avoid_get_object_attributes(self.avoid_get_object_attributes)
+                .with_no_get_object_attributes(self.no_get_object_attributes)
+                .with_no_checksum_mode(self.no_checksum_mode)
                 .set_client(self.source_client.clone())
                 .build(self.source.to_string())
                 .await?;
@@ -332,7 +340,7 @@ impl CopyTaskBuilder {
         Err(err_fn())
     }
 
-    /// Build a generate task.
+    /// Build a copy task.
     pub async fn build(self) -> Result<CopyTask> {
         if self.source.is_empty() || self.destination.is_empty() {
             return Err(CopyError("source and destination required".to_string()));

--- a/copyrite/src/task/copy.rs
+++ b/copyrite/src/task/copy.rs
@@ -8,9 +8,9 @@ use crate::cli::{CopyMode, MetadataCopy};
 use crate::error::Error::CopyError;
 use crate::error::{ApiError, Error, Result};
 use crate::io::Provider;
+use crate::io::S3Client;
 use crate::io::copy::{CopyResult, CopyState, MultiPartOptions, ObjectCopy, ObjectCopyBuilder};
 use crate::io::sums::ObjectSumsBuilder;
-use aws_sdk_s3::Client;
 use console::style;
 use futures_util::future::join_all;
 use indicatif::{HumanBytes, ProgressBar, ProgressState, ProgressStyle};
@@ -18,7 +18,6 @@ use std::cmp::min;
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter, Write};
 use std::future::Future;
-use std::sync::Arc;
 use std::{fmt, result};
 
 pub const DEFAULT_MULTIPART_THRESHOLD: u64 = 8 * 1024 * 1024; // 8mib
@@ -33,12 +32,10 @@ pub struct CopyTaskBuilder {
     metadata_mode: MetadataCopy,
     tag_mode: MetadataCopy,
     copy_mode: CopyMode,
-    source_client: Option<Arc<Client>>,
-    destination_client: Option<Arc<Client>>,
+    source_client: Option<S3Client>,
+    destination_client: Option<S3Client>,
     concurrency: Option<usize>,
     api_errors: HashSet<ApiError>,
-    no_get_object_attributes: bool,
-    no_checksum_mode: bool,
     ui: bool,
 }
 
@@ -124,13 +121,13 @@ impl CopyTaskBuilder {
     }
 
     /// Set the source S3 client to use for S3 copies.
-    pub fn with_source_client(mut self, client: Arc<Client>) -> Self {
+    pub fn with_source_client(mut self, client: S3Client) -> Self {
         self.source_client = Some(client);
         self
     }
 
     /// Set the destination S3 client to use for S3 copies.
-    pub fn with_destination_client(mut self, client: Arc<Client>) -> Self {
+    pub fn with_destination_client(mut self, client: S3Client) -> Self {
         self.destination_client = Some(client);
         self
     }
@@ -138,18 +135,6 @@ impl CopyTaskBuilder {
     /// Set the S3 client to use for S3 copies.
     pub fn with_concurrency(mut self, concurrency: usize) -> Self {
         self.concurrency = Some(concurrency);
-        self
-    }
-
-    /// Avoid `GetObjectAttributes` calls.
-    pub fn with_no_get_object_attributes(mut self, no_get_object_attributes: bool) -> Self {
-        self.no_get_object_attributes = no_get_object_attributes;
-        self
-    }
-
-    /// Disable checksum mode on `HeadObject` calls.
-    pub fn with_no_checksum_mode(mut self, no_checksum_mode: bool) -> Self {
-        self.no_checksum_mode = no_checksum_mode;
         self
     }
 
@@ -248,8 +233,6 @@ impl CopyTaskBuilder {
         // Only use the sums file if the size is not set at the source.
         let sums = if self.part_size.is_none() {
             let mut object = ObjectSumsBuilder::default()
-                .with_no_get_object_attributes(self.no_get_object_attributes)
-                .with_no_checksum_mode(self.no_checksum_mode)
                 .set_client(self.source_client.clone())
                 .build(self.source.to_string())
                 .await?;
@@ -730,6 +713,7 @@ pub(crate) mod test {
     use crate::test::{TEST_FILE_SIZE, TestFileBuilder};
     use anyhow::Result;
     use aws_sdk_s3::Client;
+    use std::sync::Arc;
     use aws_sdk_s3::operation::get_object::GetObjectError;
     use aws_sdk_s3::operation::get_object_tagging::GetObjectTaggingOutput;
     use aws_sdk_s3::operation::head_object::HeadObjectOutput;
@@ -781,37 +765,37 @@ pub(crate) mod test {
         let lt_threshold = builder
             .clone()
             .with_multipart_threshold(Some(TEST_FILE_SIZE + 1))
-            .with_source_client(Arc::new(mock_size(
+            .with_source_client(S3Client::new(Arc::new(mock_size(
                 TEST_FILE_SIZE,
                 mock_single_part_etag_only_rule(),
-            )));
+            )), false, false));
         assert_eq!(lt_threshold.build().await?.part_size, None);
 
         // S3 to S3 will always prefer the original upload settings so even if the size is greater than the
         // threshold, it should still be single part.
-        let gt_threshold = builder.clone().with_source_client(Arc::new(mock_size(
+        let gt_threshold = builder.clone().with_source_client(S3Client::new(Arc::new(mock_size(
             TEST_FILE_SIZE,
             mock_single_part_etag_only_rule(),
-        )));
+        )), false, false));
         assert_eq!(gt_threshold.build().await?.part_size, None);
 
         // If it was originally multipart, it should prefer that even if below the threshold.
         let multipart_lt_threshold = builder
             .clone()
             .with_multipart_threshold(Some(TEST_FILE_SIZE + 1))
-            .with_source_client(Arc::new(mock_size(
+            .with_source_client(S3Client::new(Arc::new(mock_size(
                 TEST_FILE_SIZE,
                 mock_multi_part_etag_only_rule(),
-            )));
+            )), false, false));
         assert_eq!(
             multipart_lt_threshold.build().await?.part_size,
             Some(214748365)
         );
 
-        let multipart_gt_threshold = builder.clone().with_source_client(Arc::new(mock_size(
+        let multipart_gt_threshold = builder.clone().with_source_client(S3Client::new(Arc::new(mock_size(
             TEST_FILE_SIZE,
             mock_multi_part_etag_only_rule(),
-        )));
+        )), false, false));
         assert_eq!(
             multipart_gt_threshold.build().await?.part_size,
             Some(214748365)
@@ -821,18 +805,18 @@ pub(crate) mod test {
         let part_size_set = builder
             .clone()
             .with_part_size(Some(5242880))
-            .with_source_client(Arc::new(mock_size(
+            .with_source_client(S3Client::new(Arc::new(mock_size(
                 TEST_FILE_SIZE,
                 mock_single_part_etag_only_rule(),
-            )));
+            )), false, false));
         assert_eq!(part_size_set.build().await?.part_size, Some(5242880));
         let part_size_set_multipart = builder
             .clone()
             .with_part_size(Some(5242880))
-            .with_source_client(Arc::new(mock_size(
+            .with_source_client(S3Client::new(Arc::new(mock_size(
                 TEST_FILE_SIZE,
                 mock_multi_part_etag_only_rule(),
-            )));
+            )), false, false));
         assert_eq!(
             part_size_set_multipart.build().await?.part_size,
             Some(5242880)
@@ -861,20 +845,20 @@ pub(crate) mod test {
         let part_size_err_max = builder
             .clone()
             .with_part_size(Some(60000000000))
-            .with_source_client(Arc::new(mock_size(
+            .with_source_client(S3Client::new(Arc::new(mock_size(
                 TEST_FILE_SIZE,
                 mock_single_part_etag_only_rule(),
-            )));
+            )), false, false));
         assert!(part_size_err_max.build().await.is_err());
         // If the part size exceeds the limits, this should be an error.
         let part_size_err_min =
             builder
                 .clone()
                 .with_part_size(Some(1))
-                .with_source_client(Arc::new(mock_size(
+                .with_source_client(S3Client::new(Arc::new(mock_size(
                     TEST_FILE_SIZE,
                     mock_single_part_etag_only_rule(),
-                )));
+                )), false, false));
         assert!(part_size_err_min.build().await.is_err());
 
         Ok(())

--- a/copyrite/src/task/copy.rs
+++ b/copyrite/src/task/copy.rs
@@ -823,13 +823,20 @@ pub(crate) mod test {
         );
 
         // If there are no AWS metadata sums, then use a defaulted value.
+        let destination_client = S3Client::new(Arc::new(mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[]
+        )), false, false);
         let no_metadata_sums = builder
             .clone()
+            .with_destination_client(destination_client.clone())
             .with_source(test_file.to_string_lossy().to_string());
         assert_eq!(no_metadata_sums.build().await?.part_size, Some(8388608));
         let no_metadata_sums_part_size = builder
             .clone()
             .with_part_size(Some(5242880))
+            .with_destination_client(destination_client.clone())
             .with_source(test_file.to_string_lossy().to_string());
         assert_eq!(
             no_metadata_sums_part_size.build().await?.part_size,
@@ -838,6 +845,7 @@ pub(crate) mod test {
         let no_metadata_sums_single_part = builder
             .clone()
             .with_multipart_threshold(Some(TEST_FILE_SIZE))
+            .with_destination_client(destination_client)
             .with_source(test_file.to_string_lossy().to_string());
         assert_eq!(no_metadata_sums_single_part.build().await?.part_size, None);
 

--- a/copyrite/src/task/copy.rs
+++ b/copyrite/src/task/copy.rs
@@ -344,35 +344,22 @@ impl CopyTaskBuilder {
             CopyMode::DownloadUpload
         };
 
-        let (source_copy, destination_copy) = if copy_mode.is_server_side() {
-            let source = ObjectCopyBuilder::default()
-                .with_copy_metadata(self.metadata_mode)
-                .with_copy_tags(self.tag_mode)
-                .set_client(self.source_client.clone())
-                .set_source(Some(source.clone()))
-                .set_destination(Some(destination.clone()))
-                .build()
-                .await?;
-
-            (source.clone(), source)
-        } else {
-            (
-                ObjectCopyBuilder::default()
-                    .with_copy_metadata(self.metadata_mode)
-                    .with_copy_tags(self.tag_mode)
-                    .set_client(self.source_client.clone())
-                    .set_source(Some(source.clone()))
-                    .build()
-                    .await?,
-                ObjectCopyBuilder::default()
-                    .with_copy_metadata(self.metadata_mode)
-                    .with_copy_tags(self.tag_mode)
-                    .set_client(self.destination_client.clone())
-                    .set_destination(Some(destination.clone()))
-                    .build()
-                    .await?,
-            )
-        };
+        let source_copy = ObjectCopyBuilder::default()
+            .with_copy_metadata(self.metadata_mode)
+            .with_copy_tags(self.tag_mode)
+            .set_client(self.source_client.clone())
+            .set_source(Some(source.clone()))
+            .build()
+            .await?;
+        let mut destination_builder = ObjectCopyBuilder::default()
+            .with_copy_metadata(self.metadata_mode)
+            .with_copy_tags(self.tag_mode)
+            .set_client(self.destination_client.clone())
+            .set_destination(Some(destination.clone()));
+        if copy_mode.is_server_side() {
+            destination_builder = destination_builder.set_source(Some(source.clone()));
+        }
+        let destination_copy = destination_builder.build().await?;
 
         let state = source_copy.initialize_state().await?;
 
@@ -617,17 +604,17 @@ impl CopyTask {
 
         match (self.copy_mode, self.part_size) {
             (CopyMode::ServerSide, None) => {
-                let copy = self.source_copy.copy(None, &self.state).await?;
+                let copy = self.destination_copy.copy(None, &self.state).await?;
 
                 self.update_bytes(copy.bytes_transferred);
                 self.n_retries += copy.n_retries;
                 self.recoverable_errors.extend(copy.api_errors);
             }
             (CopyMode::ServerSide, Some(part_size)) => {
-                let source = self.source_copy.clone();
+                let destination = self.destination_copy.clone();
                 self.run_multipart(
                     part_size,
-                    |option, state| async move { source.copy(Some(option), &state).await },
+                    |option, state| async move { destination.copy(Some(option), &state).await },
                     |result, _, _| async move { Ok(result) },
                 )
                 .await?
@@ -757,10 +744,17 @@ pub(crate) mod test {
     async fn copy_settings() -> Result<()> {
         let test_file = TestFileBuilder::new()?.generate_test_defaults()?;
 
+        let destination_client = S3Client::new(Arc::new(mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[]
+        )), false, false);
+
         let builder = CopyTaskBuilder::default()
             .with_concurrency(10)
             .with_source("s3://bucket/key".to_string())
-            .with_destination("s3://bucket/key2".to_string());
+            .with_destination("s3://bucket/key2".to_string())
+            .with_destination_client(destination_client);
 
         let lt_threshold = builder
             .clone()

--- a/copyrite/src/task/copy.rs
+++ b/copyrite/src/task/copy.rs
@@ -700,12 +700,12 @@ pub(crate) mod test {
     use crate::test::{TEST_FILE_SIZE, TestFileBuilder};
     use anyhow::Result;
     use aws_sdk_s3::Client;
-    use std::sync::Arc;
     use aws_sdk_s3::operation::get_object::GetObjectError;
     use aws_sdk_s3::operation::get_object_tagging::GetObjectTaggingOutput;
     use aws_sdk_s3::operation::head_object::HeadObjectOutput;
     use aws_sdk_s3::types::error::NoSuchKey;
     use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
+    use std::sync::Arc;
     use tempfile::tempdir;
     use tokio::fs::File;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -744,11 +744,11 @@ pub(crate) mod test {
     async fn copy_settings() -> Result<()> {
         let test_file = TestFileBuilder::new()?.generate_test_defaults()?;
 
-        let destination_client = S3Client::new(Arc::new(mock_client!(
-            aws_sdk_s3,
-            RuleMode::Sequential,
-            &[]
-        )), false, false);
+        let destination_client = S3Client::new(
+            Arc::new(mock_client!(aws_sdk_s3, RuleMode::Sequential, &[])),
+            false,
+            false,
+        );
 
         let builder = CopyTaskBuilder::default()
             .with_concurrency(10)
@@ -759,37 +759,41 @@ pub(crate) mod test {
         let lt_threshold = builder
             .clone()
             .with_multipart_threshold(Some(TEST_FILE_SIZE + 1))
-            .with_source_client(S3Client::new(Arc::new(mock_size(
-                TEST_FILE_SIZE,
-                mock_single_part_etag_only_rule(),
-            )), false, false));
+            .with_source_client(S3Client::new(
+                Arc::new(mock_size(TEST_FILE_SIZE, mock_single_part_etag_only_rule())),
+                false,
+                false,
+            ));
         assert_eq!(lt_threshold.build().await?.part_size, None);
 
         // S3 to S3 will always prefer the original upload settings so even if the size is greater than the
         // threshold, it should still be single part.
-        let gt_threshold = builder.clone().with_source_client(S3Client::new(Arc::new(mock_size(
-            TEST_FILE_SIZE,
-            mock_single_part_etag_only_rule(),
-        )), false, false));
+        let gt_threshold = builder.clone().with_source_client(S3Client::new(
+            Arc::new(mock_size(TEST_FILE_SIZE, mock_single_part_etag_only_rule())),
+            false,
+            false,
+        ));
         assert_eq!(gt_threshold.build().await?.part_size, None);
 
         // If it was originally multipart, it should prefer that even if below the threshold.
         let multipart_lt_threshold = builder
             .clone()
             .with_multipart_threshold(Some(TEST_FILE_SIZE + 1))
-            .with_source_client(S3Client::new(Arc::new(mock_size(
-                TEST_FILE_SIZE,
-                mock_multi_part_etag_only_rule(),
-            )), false, false));
+            .with_source_client(S3Client::new(
+                Arc::new(mock_size(TEST_FILE_SIZE, mock_multi_part_etag_only_rule())),
+                false,
+                false,
+            ));
         assert_eq!(
             multipart_lt_threshold.build().await?.part_size,
             Some(214748365)
         );
 
-        let multipart_gt_threshold = builder.clone().with_source_client(S3Client::new(Arc::new(mock_size(
-            TEST_FILE_SIZE,
-            mock_multi_part_etag_only_rule(),
-        )), false, false));
+        let multipart_gt_threshold = builder.clone().with_source_client(S3Client::new(
+            Arc::new(mock_size(TEST_FILE_SIZE, mock_multi_part_etag_only_rule())),
+            false,
+            false,
+        ));
         assert_eq!(
             multipart_gt_threshold.build().await?.part_size,
             Some(214748365)
@@ -799,29 +803,31 @@ pub(crate) mod test {
         let part_size_set = builder
             .clone()
             .with_part_size(Some(5242880))
-            .with_source_client(S3Client::new(Arc::new(mock_size(
-                TEST_FILE_SIZE,
-                mock_single_part_etag_only_rule(),
-            )), false, false));
+            .with_source_client(S3Client::new(
+                Arc::new(mock_size(TEST_FILE_SIZE, mock_single_part_etag_only_rule())),
+                false,
+                false,
+            ));
         assert_eq!(part_size_set.build().await?.part_size, Some(5242880));
         let part_size_set_multipart = builder
             .clone()
             .with_part_size(Some(5242880))
-            .with_source_client(S3Client::new(Arc::new(mock_size(
-                TEST_FILE_SIZE,
-                mock_multi_part_etag_only_rule(),
-            )), false, false));
+            .with_source_client(S3Client::new(
+                Arc::new(mock_size(TEST_FILE_SIZE, mock_multi_part_etag_only_rule())),
+                false,
+                false,
+            ));
         assert_eq!(
             part_size_set_multipart.build().await?.part_size,
             Some(5242880)
         );
 
         // If there are no AWS metadata sums, then use a defaulted value.
-        let destination_client = S3Client::new(Arc::new(mock_client!(
-            aws_sdk_s3,
-            RuleMode::Sequential,
-            &[]
-        )), false, false);
+        let destination_client = S3Client::new(
+            Arc::new(mock_client!(aws_sdk_s3, RuleMode::Sequential, &[])),
+            false,
+            false,
+        );
         let no_metadata_sums = builder
             .clone()
             .with_destination_client(destination_client.clone())
@@ -847,20 +853,22 @@ pub(crate) mod test {
         let part_size_err_max = builder
             .clone()
             .with_part_size(Some(60000000000))
-            .with_source_client(S3Client::new(Arc::new(mock_size(
-                TEST_FILE_SIZE,
-                mock_single_part_etag_only_rule(),
-            )), false, false));
+            .with_source_client(S3Client::new(
+                Arc::new(mock_size(TEST_FILE_SIZE, mock_single_part_etag_only_rule())),
+                false,
+                false,
+            ));
         assert!(part_size_err_max.build().await.is_err());
         // If the part size exceeds the limits, this should be an error.
         let part_size_err_min =
             builder
                 .clone()
                 .with_part_size(Some(1))
-                .with_source_client(S3Client::new(Arc::new(mock_size(
-                    TEST_FILE_SIZE,
-                    mock_single_part_etag_only_rule(),
-                )), false, false));
+                .with_source_client(S3Client::new(
+                    Arc::new(mock_size(TEST_FILE_SIZE, mock_single_part_etag_only_rule())),
+                    false,
+                    false,
+                ));
         assert!(part_size_err_min.build().await.is_err());
 
         Ok(())

--- a/copyrite/src/task/generate.rs
+++ b/copyrite/src/task/generate.rs
@@ -5,16 +5,15 @@ use crate::checksum::Ctx;
 use crate::checksum::file::{Checksum, SumsFile};
 use crate::error::Error::GenerateError;
 use crate::error::{ApiError, Error, Result};
+use crate::io::S3Client;
 use crate::io::sums::channel::ChannelReader;
 use crate::io::sums::{ObjectSums, ObjectSumsBuilder, SharedReader};
 use crate::task::check::{CheckObjects, SumsKey};
 use crate::task::generate::Task::{ChecksumTask, ReadTask};
-use aws_sdk_s3::Client;
 use futures_util::future::join_all;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::result;
-use std::sync::Arc;
 use tokio::task::JoinHandle;
 
 /// Define the kind of task that is running.
@@ -34,9 +33,7 @@ pub struct GenerateTaskBuilder {
     reader: Option<Box<dyn SharedReader + Send>>,
     capacity: usize,
     write: bool,
-    client: Option<Arc<Client>>,
-    no_get_object_attributes: bool,
-    no_checksum_mode: bool,
+    client: Option<S3Client>,
 }
 
 impl GenerateTaskBuilder {
@@ -77,12 +74,12 @@ impl GenerateTaskBuilder {
     }
 
     /// Set the S3 client to use.
-    pub fn with_client(self, client: Arc<Client>) -> Self {
+    pub fn with_client(self, client: S3Client) -> Self {
         self.set_client(Some(client))
     }
 
     /// Set the S3 client to use.
-    pub fn set_client(mut self, client: Option<Arc<Client>>) -> Self {
+    pub fn set_client(mut self, client: Option<S3Client>) -> Self {
         self.client = client;
         self
     }
@@ -98,24 +95,10 @@ impl GenerateTaskBuilder {
         self
     }
 
-    /// Avoid `GetObjectAttributes` calls.
-    pub fn with_no_get_object_attributes(mut self, no_get_object_attributes: bool) -> Self {
-        self.no_get_object_attributes = no_get_object_attributes;
-        self
-    }
-
-    /// Disable checksum mode on `HeadObject` calls.
-    pub fn with_no_checksum_mode(mut self, no_checksum_mode: bool) -> Self {
-        self.no_checksum_mode = no_checksum_mode;
-        self
-    }
-
     /// Build a generate task.
     pub async fn build(mut self) -> Result<GenerateTask> {
         let mut sums = ObjectSumsBuilder::default()
             .set_client(self.client)
-            .with_no_get_object_attributes(self.no_get_object_attributes)
-            .with_no_checksum_mode(self.no_checksum_mode)
             .build(self.input_file_name.to_string())
             .await?;
 

--- a/copyrite/src/task/generate.rs
+++ b/copyrite/src/task/generate.rs
@@ -35,7 +35,8 @@ pub struct GenerateTaskBuilder {
     capacity: usize,
     write: bool,
     client: Option<Arc<Client>>,
-    avoid_get_object_attributes: bool,
+    no_get_object_attributes: bool,
+    no_checksum_mode: bool,
 }
 
 impl GenerateTaskBuilder {
@@ -98,8 +99,14 @@ impl GenerateTaskBuilder {
     }
 
     /// Avoid `GetObjectAttributes` calls.
-    pub fn with_avoid_get_object_attributes(mut self, avoid_get_object_attributes: bool) -> Self {
-        self.avoid_get_object_attributes = avoid_get_object_attributes;
+    pub fn with_no_get_object_attributes(mut self, no_get_object_attributes: bool) -> Self {
+        self.no_get_object_attributes = no_get_object_attributes;
+        self
+    }
+
+    /// Disable checksum mode on `HeadObject` calls.
+    pub fn with_no_checksum_mode(mut self, no_checksum_mode: bool) -> Self {
+        self.no_checksum_mode = no_checksum_mode;
         self
     }
 
@@ -107,7 +114,8 @@ impl GenerateTaskBuilder {
     pub async fn build(mut self) -> Result<GenerateTask> {
         let mut sums = ObjectSumsBuilder::default()
             .set_client(self.client)
-            .with_avoid_get_object_attributes(self.avoid_get_object_attributes)
+            .with_no_get_object_attributes(self.no_get_object_attributes)
+            .with_no_checksum_mode(self.no_checksum_mode)
             .build(self.input_file_name.to_string())
             .await?;
 

--- a/copyrite/tests/copy.rs
+++ b/copyrite/tests/copy.rs
@@ -74,6 +74,7 @@ async fn copy_test() -> Result<()> {
         config.endpoint_url.as_deref(),
         None,
         no_overrides,
+        false,
     )
     .await?;
 

--- a/copyrite/tests/copy.rs
+++ b/copyrite/tests/copy.rs
@@ -22,6 +22,9 @@ use tempfile::TempDir;
 struct TestConfig {
     bucket_uri: String,
     endpoint_url: Option<String>,
+    secret: Option<String>,
+    region: Option<String>,
+    s3_compatible: Option<bool>,
 }
 
 impl TestConfig {
@@ -43,11 +46,23 @@ impl TestConfig {
         Ok(env)
     }
 
+    fn credential_provider(&self) -> CredentialProvider {
+        if self.secret.is_some() {
+            CredentialProvider::AwsSecret
+        } else {
+            CredentialProvider::DefaultEnvironment
+        }
+    }
+
+    fn is_s3_compatible(&self) -> bool {
+        self.s3_compatible.unwrap_or(false)
+    }
+
     fn format_uri(&self, path: &str) -> String {
         format!("{}/{}", self.bucket_uri, path)
     }
 
-    fn set_endpoint_url(&self, mut commands: Vec<String>) -> Vec<String> {
+    fn set_cli_options(&self, mut commands: Vec<String>) -> Vec<String> {
         if let Some(endpoint_url) = &self.endpoint_url {
             commands.extend([
                 "--source-endpoint-url".to_string(),
@@ -55,6 +70,19 @@ impl TestConfig {
                 "--destination-endpoint-url".to_string(),
                 endpoint_url.to_string(),
             ]);
+        }
+        if let Some(secret) = &self.secret {
+            commands.extend([
+                "--credential-provider".to_string(),
+                "aws-secret".to_string(),
+            ]);
+            commands.extend(["--secret".to_string(), secret.to_string()]);
+        }
+        if let Some(region) = &self.region {
+            commands.extend(["--region".to_string(), region.to_string()]);
+        }
+        if self.is_s3_compatible() {
+            commands.push("--s3-compatible".to_string());
         }
 
         commands
@@ -68,13 +96,13 @@ async fn copy_test() -> Result<()> {
     let file = TestFileBuilder::new()?.generate_bench_defaults()?;
     let no_overrides = CredentialOverrides::new(None, None, None);
     let client = S3Client::create_s3_client(
-        &CredentialProvider::DefaultEnvironment,
+        &config.credential_provider(),
         None,
-        None,
+        config.region.as_deref(),
         config.endpoint_url.as_deref(),
-        None,
+        config.secret.as_deref(),
         no_overrides,
-        false,
+        config.is_s3_compatible(),
     )
     .await?;
 
@@ -100,7 +128,7 @@ async fn local_s3_multipart(file: &Path, config: &TestConfig, client: &Client) -
 
     execute_multipart(file.as_ref(), uri.as_ref(), config).await;
 
-    let head = get_head_object(client, uri.as_ref()).await?;
+    let head = get_head_object(client, uri.as_ref(), config).await?;
     assert_head_multipart(head);
 
     Ok(())
@@ -113,7 +141,7 @@ async fn local_s3_single_part(file: &Path, config: &TestConfig, client: &Client)
 
     execute_single_part(file.as_ref(), uri.as_ref(), config).await;
 
-    let head = get_head_object(client, uri.as_ref()).await?;
+    let head = get_head_object(client, uri.as_ref(), config).await?;
     assert_head_single_part(head);
 
     Ok(())
@@ -126,7 +154,7 @@ async fn s3_s3_multipart(config: &TestConfig, client: &Client) -> Result<()> {
 
     execute_multipart(uri.as_ref(), destination.as_ref(), config).await;
 
-    let head = get_head_object(client, destination.as_ref()).await?;
+    let head = get_head_object(client, destination.as_ref(), config).await?;
     assert_head_multipart(head);
 
     Ok(())
@@ -139,7 +167,7 @@ async fn s3_s3_single_part(config: &TestConfig, client: &Client) -> Result<()> {
 
     execute_single_part(uri.as_ref(), destination.as_ref(), config).await;
 
-    let head = get_head_object(client, destination.as_ref()).await?;
+    let head = get_head_object(client, destination.as_ref(), config).await?;
     assert_head_single_part(head);
 
     Ok(())
@@ -186,15 +214,17 @@ fn assert_original(original: &str, copy: &str) -> Result<()> {
     Ok(())
 }
 
-async fn get_head_object(client: &Client, url: &str) -> Result<HeadObjectOutput> {
+async fn get_head_object(
+    client: &Client,
+    url: &str,
+    config: &TestConfig,
+) -> Result<HeadObjectOutput> {
     let (bucket, key) = Provider::try_from(url)?.into_s3()?;
-    let head = client
-        .head_object()
-        .bucket(bucket)
-        .key(key)
-        .checksum_mode(ChecksumMode::Enabled)
-        .send()
-        .await?;
+    let mut req = client.head_object().bucket(bucket).key(key);
+    if !config.is_s3_compatible() {
+        req = req.checksum_mode(ChecksumMode::Enabled);
+    }
+    let head = req.send().await?;
     Ok(head)
 }
 
@@ -214,7 +244,7 @@ async fn execute_multipart(from: &str, to: &str, config: &TestConfig) {
     .into_iter()
     .map(|s| s.to_string())
     .collect();
-    commands = config.set_endpoint_url(commands);
+    commands = config.set_cli_options(commands);
 
     execute_command(&commands).await;
 }
@@ -235,7 +265,7 @@ async fn execute_single_part(from: &str, to: &str, config: &TestConfig) {
     .into_iter()
     .map(|s| s.to_string())
     .collect();
-    commands = config.set_endpoint_url(commands);
+    commands = config.set_cli_options(commands);
 
     execute_command(&commands).await;
 }

--- a/copyrite/tests/copy.rs
+++ b/copyrite/tests/copy.rs
@@ -7,7 +7,7 @@ use aws_sdk_s3::Client;
 use aws_sdk_s3::operation::head_object::HeadObjectOutput;
 use aws_sdk_s3::types::ChecksumMode;
 use copyrite::cli::{Command, CredentialProvider};
-use copyrite::io::{CredentialOverrides, Provider, create_s3_client};
+use copyrite::io::{CredentialOverrides, Provider, S3Client};
 use copyrite::test::TestFileBuilder;
 use dotenvy::dotenv;
 use envy::prefixed;
@@ -67,7 +67,7 @@ async fn copy_test() -> Result<()> {
     let config = TestConfig::load()?;
     let file = TestFileBuilder::new()?.generate_bench_defaults()?;
     let no_overrides = CredentialOverrides::new(None, None, None);
-    let client = create_s3_client(
+    let client = S3Client::create_s3_client(
         &CredentialProvider::DefaultEnvironment,
         None,
         None,


### PR DESCRIPTION
A few changes and fixes

### Fixes
* Server-side copies should use the destination client because that's what `CopyObject` would expect. 
    * In practice this probably wouldn't have made a difference because server-side would have the same source and destination credentials.
* Interestingly, ceph returns part sizes differently to S3, which is important when computing the etag. S3 returns the part-size for the requested part, whereas ceph always returns the size of the full object for a part-request. This previously broke the etag calculation which is now fixed.

### Features/Refactor
* New compatibility options to force path style addressing and avoid checksum mode, both of these are required for ceph.
* I think the CLI modelling is now correct in relation to credentials/compatibility. It's now possible to specify source/destination for both compatibility options and credential options. 
    * If using the un-prefixed version, it sets the field for both source and destination. 
    * For non-copy commands, only the un-prefixed version is available (as it doesn't make sense to have a source or destination generate/check). 
* I've added a wrapper to S3Client which carries compatibility options along with it. I think this makes it easier to reason about which commands get credentials/compatibility options, as the wrapper goes all the way down to where it's used to call the S3 API.
    
### Tests 
* Allow setting more options in the integration tests a sourcing from a secret, which makes testing with ceph easier. 