### PR TITLE
fix: publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,15 +12,15 @@ on:
 
 jobs:
   docker:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
-      pull-requests: write
       packages: write
     name: docker
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 #      - name: Set up QEMU
@@ -28,7 +28,7 @@ jobs:
 #        with:
 #         platforms: "linux/amd64,linux/arm64"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           use: true
           install: true
@@ -37,25 +37,26 @@ jobs:
             [worker.oci]
               max-parallelism = 2
       - name: Login to GHCR.io (GH's Container Registry)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Get release tag
         id: tag
-        uses: devops-actions/action-get-tag@v1.0.3
-        with:
-          strip_v: true # Optional: Remove 'v' character from version
-          default: v0.0.0 # Optional: Default version when tag not found
+        run: |
+          TAG="${{ github.event.workflow_run.head_branch }}"
+          echo "tag=${TAG#v}" >> $GITHUB_OUTPUT
       - name: Docker GitHub release
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: pkg/docker/Dockerfile
           provenance: false
           platforms: "linux/amd64,linux/arm64"
-#          build-args: TARGETPLATFORM, GITHUB_REPO_RELEASES_URL, PACKAGE_VERSION
+          build-args: |
+            GITHUB_REPO_RELEASES_URL=https://github.com/umccr/cloud-checksum/releases/download
+            PACKAGE_VERSION=v${{ steps.tag.outputs.tag }}
           push: true
           tags: |
             ghcr.io/umccr/copyrite:${{steps.tag.outputs.tag}}

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -80,6 +80,7 @@ jobs:
         env:
           DEB_BUILD_OPTIONS: noautodbgsym
         with:
+          docker-image: rust:1.91-bookworm
           buildpackage-opts: --build=binary --no-sign
       - name: Release Debian assets
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -58,15 +58,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y rpm debhelper
+        run: sudo apt-get update && sudo apt-get install -y rpm debhelper build-essential
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Build RPM package
-        run: |
-          RPM_VERSION=$(rpm --specfile pkg/rpm/copyrite.spec --qf '%{version}\n' | head -1)
-          mkdir -p rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-          tar czf "rpmbuild/SOURCES/copyrite-${RPM_VERSION}.tar.gz" --transform "s,^,copyrite-${RPM_VERSION}/," --exclude=rpmbuild --exclude=.git --exclude=target -C . .
-          rpmbuild --define "_topdir $(pwd)/rpmbuild" --nodeps -bb pkg/rpm/copyrite.spec
+        run: rpmbuild --define "_topdir $(pwd)/rpmbuild" --build-in-place --nodeps -bb pkg/rpm/copyrite.spec
       - name: Release RPM assets
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -57,42 +57,31 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Determine arch
-        run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
-      - name: Builder/runner arch is...
-        run: echo "runner.arch=${{ runner.arch }}, uname=$ARCH"
-      - name: build RPM package
-        id: rpm_build
-        uses: naveenrajm7/rpmbuild@master
+      - name: Install RPM tools
+        run: sudo apt-get update && sudo apt-get install -y rpm rpmbuild || sudo apt-get install -y rpm
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build RPM package
+        run: |
+          RPM_VERSION=$(rpm --specfile pkg/rpm/copyrite.spec --qf '%{version}\n' | head -1)
+          mkdir -p rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+          tar czf "rpmbuild/SOURCES/copyrite-${RPM_VERSION}.tar.gz" --transform "s,^,copyrite-${RPM_VERSION}/," --exclude=rpmbuild --exclude=.git --exclude=target -C . .
+          rpmbuild --define "_topdir $(pwd)/rpmbuild" -bb pkg/rpm/copyrite.spec
+      - name: Release RPM assets
+        uses: softprops/action-gh-release@v2
         with:
-          spec_file: "./pkg/rpm/copyrite.spec"
+          files: rpmbuild/RPMS/**/*.rpm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # See https://github.com/jtdor/build-deb-action/issues/17#issuecomment-3434202578
       - run: cp -r pkg/debian .
-      - name: build-debian-package
+      - name: Build Debian package
         uses: jtdor/build-deb-action@v1
         env:
           DEB_BUILD_OPTIONS: noautodbgsym
         with:
           buildpackage-opts: --build=binary --no-sign
-      - name: find .deb assets
-        run: echo $PWD && find . -iname '*.deb'
-      - name: Release debian assets
+      - name: Release Debian assets
         uses: softprops/action-gh-release@v2
         with:
           files: ./debian/artifacts/*.deb
-      - name: Determine arch and rpm path
-        id: rpm_info
-        run: |
-          arch=$(uname -m)
-          echo "arch=$arch" >> $GITHUB_OUTPUT
-          echo "rpm_path=rpmbuild/RPMS/$arch" >> $GITHUB_OUTPUT
-      - name: Builder/runner arch is...
-        run: echo "runner.arch=${{ runner.arch }}, uname=${{ steps.rpm_info.outputs.arch }}"
-      - name: Setup arch path
-        run: echo "RPM_ARCH_PATH=rpmbuild/RPMS/$ARCH" >> $GITHUB_ENV
-      - name: Release rpm assets
-        uses: softprops/action-gh-release@v2
-        with:
-          files: ${{ steps.rpm_info.outputs.rpm_path }}/*.rpm
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04-arm
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-apple-darwin
@@ -50,7 +50,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04-arm
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -57,8 +57,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Install RPM tools
-        run: sudo apt-get update && sudo apt-get install -y rpm rpmbuild || sudo apt-get install -y rpm
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y rpm debhelper
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Build RPM package
@@ -73,16 +73,13 @@ jobs:
           files: rpmbuild/RPMS/**/*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # See https://github.com/jtdor/build-deb-action/issues/17#issuecomment-3434202578
-      - run: cp -r pkg/debian .
       - name: Build Debian package
-        uses: jtdor/build-deb-action@v1
         env:
           DEB_BUILD_OPTIONS: noautodbgsym
-        with:
-          docker-image: rust:1.91-bookworm
-          buildpackage-opts: --build=binary --no-sign
+        run: |
+          cp -r pkg/debian .
+          dpkg-buildpackage --build=binary --no-sign
       - name: Release Debian assets
         uses: softprops/action-gh-release@v2
         with:
-          files: ./debian/artifacts/*.deb
+          files: ../*.deb

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -3,18 +3,21 @@ name: release-binaries
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.*'
 
 jobs:
   create-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: taiki-e/create-gh-release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
   release-binary-assets:
-    permissions: write-all
+    permissions:
+      contents: write
     needs: create-release
     strategy:
       matrix:
@@ -31,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: copyrite
@@ -40,7 +43,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   release-linux-packages:
-    permissions: write-all
+    permissions:
+      contents: write
     needs: create-release
     strategy:
       matrix:
@@ -52,14 +56,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Determine arch
         run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
       - name: Builder/runner arch is...
         run: echo "runner.arch=${{ runner.arch }}, uname=$ARCH"
       - name: build RPM package
         id: rpm_build
-        uses: naveenrajm7/rpmbuild@master
+        uses: naveenrajm7/rpmbuild@v1.0.0
         with:
           spec_file: "./pkg/rpm/copyrite.spec"
       # See https://github.com/jtdor/build-deb-action/issues/17#issuecomment-3434202578

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -63,7 +63,7 @@ jobs:
         run: echo "runner.arch=${{ runner.arch }}, uname=$ARCH"
       - name: build RPM package
         id: rpm_build
-        uses: naveenrajm7/rpmbuild@v1.0.0
+        uses: naveenrajm7/rpmbuild@master
         with:
           spec_file: "./pkg/rpm/copyrite.spec"
       # See https://github.com/jtdor/build-deb-action/issues/17#issuecomment-3434202578

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -23,13 +23,13 @@ jobs:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -50,7 +50,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
@@ -66,7 +66,7 @@ jobs:
           RPM_VERSION=$(rpm --specfile pkg/rpm/copyrite.spec --qf '%{version}\n' | head -1)
           mkdir -p rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
           tar czf "rpmbuild/SOURCES/copyrite-${RPM_VERSION}.tar.gz" --transform "s,^,copyrite-${RPM_VERSION}/," --exclude=rpmbuild --exclude=.git --exclude=target -C . .
-          rpmbuild --define "_topdir $(pwd)/rpmbuild" -bb pkg/rpm/copyrite.spec
+          rpmbuild --define "_topdir $(pwd)/rpmbuild" --nodeps -bb pkg/rpm/copyrite.spec
       - name: Release RPM assets
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-crate.yml
+++ b/.github/workflows/release-crate.yml
@@ -24,3 +24,4 @@ jobs:
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.COPYRITE_CRATES_IO_TOKEN }}

--- a/.github/workflows/release-crate.yml
+++ b/.github/workflows/release-crate.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Rust

--- a/.github/workflows/release-crate.yml
+++ b/.github/workflows/release-crate.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     name: Release-plz
     runs-on: ubuntu-latest
     steps:
@@ -23,4 +24,3 @@ jobs:
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.HTSGET_RS_CRATES_IO_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "copyrite"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/copyrite/Cargo.toml
+++ b/copyrite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "copyrite"
 description = "A CLI tool for efficient checksum and copy operations across object stores"
-version = "0.1.0"
+version = "0.3.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -1,3 +1,9 @@
+copyrite (0.3.0-1) unstable; urgency=low
+
+  * Release 0.3.0
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Fri, 10 Apr 2026 00:00:00 +0000
+
 copyrite (0.1.0-1) unstable; urgency=low
 
   * Initial release

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -2,7 +2,7 @@ Source: copyrite
 Section: utils
 Priority: optional
 Maintainer: Marko Malenic <mmalenic1@gmail.com>
-Build-Depends: debhelper-compat (= 13), rustc:native, cargo:native, pkg-config, libssl-dev, ca-certificates
+Build-Depends: debhelper-compat (= 13)
 Standards-Version: 4.6.2
 
 Package: copyrite

--- a/pkg/docker/Dockerfile
+++ b/pkg/docker/Dockerfile
@@ -16,9 +16,9 @@ WORKDIR /build
 RUN \
     # Set boolean \
     if [ "${TARGETPLATFORM#linux/}" = "arm64" ]; then \
-      platform_url="aarch64";  \
+      platform_url="aarch64-unknown-linux-gnu";  \
     else \
-      platform_url="x86_64"; \
+      platform_url="x86_64-unknown-linux-gnu"; \
     fi && \
     # Install
     echo "Standard APT" 1>&2 && \
@@ -29,7 +29,7 @@ RUN \
     wget \
       --quiet \
       --output-document - \
-      "${GITHUB_REPO_RELEASES_URL}/${PACKAGE_VERSION}/copyrite-${platform_url}-linux-gnu.tar.gz" | \
+      "${GITHUB_REPO_RELEASES_URL}/${PACKAGE_VERSION}/copyrite-${platform_url}.tar.gz" | \
     tar \
       --directory /usr/bin \
       --extract \

--- a/pkg/docker/Dockerfile
+++ b/pkg/docker/Dockerfile
@@ -6,9 +6,9 @@ LABEL org.opencontainers.image.description="CLI tool for efficient checksum and 
 LABEL org.opencontainers.image.licenses=MIT
 LABEL org.opencontainers.image.authors="Marko Malenic <mmalenic1@gmail.com>"
 
-ARG TARGETOS
+ARG TARGETPLATFORM
 ARG GITHUB_REPO_RELEASES_URL
-ARG TARGETARCH
+ARG PACKAGE_VERSION
 
 WORKDIR /build
 

--- a/pkg/rpm/copyrite.spec
+++ b/pkg/rpm/copyrite.spec
@@ -5,18 +5,11 @@ Summary:        CLI tool for efficient checksum and copy operations across objec
 
 License:        MIT
 URL:            https://github.com/mmalenic/copyrite
-Source0:        %{name}-%{version}.tar.gz
-
-BuildRequires:  rustc
-BuildRequires:  cargo
 
 %global debug_package %{nil}
 
 %description
 A CLI tool for efficient checksum and copy operations across object stores.
-
-%prep
-%autosetup
 
 %build
 cargo build --release

--- a/pkg/rpm/copyrite.spec
+++ b/pkg/rpm/copyrite.spec
@@ -1,5 +1,5 @@
 Name:           copyrite
-Version:        0.1.0
+Version:        0.3.0
 Release:        1%{?dist}
 Summary:        CLI tool for efficient checksum and copy operations across object stores
 
@@ -28,5 +28,8 @@ install -D target/release/%{name} %{buildroot}%{_bindir}/%{name}
 %{_bindir}/%{name}
 
 %changelog
+* Fri Apr 10 2026 Marko Malenic <mmalenic1@gmail.com> - 0.3.0-1
+- Release 0.3.0
+
 * Wed Oct 22 2025 Marko Malenic <mmalenic1@gmail.com> - 0.1.0-1
 - Initial package


### PR DESCRIPTION
### Changes
* I've updated the workflow versions and the release binary name in the Dockerfile.
* This will start a new release from v0.3.0.
    * This is with the new package name "copyrite". That means there won't be a 0.1.0 or 0.2.0 for "copyrite" (but there is cloud-checksum versions under those names).
* Fixed the rpm and debian builds.
    * Both of these avoid the actions which weren't working properly and just call rpmbuild/dpkg-buildpackage directly.

Note - trusted publishing requires an initial release, I'll update after merging this.