### PR TITLE
ci: use trusted publishing

### DIFF
--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -1,24 +1,13 @@
 name: release-binaries
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.*'
+  release:
+    types: [published]
 
 jobs:
-  create-release:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: taiki-e/create-gh-release-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
   release-binary-assets:
     permissions:
       contents: write
-    needs: create-release
     strategy:
       matrix:
         include:
@@ -45,7 +34,6 @@ jobs:
   release-linux-packages:
     permissions:
       contents: write
-    needs: create-release
     strategy:
       matrix:
         include:

--- a/.github/workflows/release-crate.yml
+++ b/.github/workflows/release-crate.yml
@@ -24,4 +24,3 @@ jobs:
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.COPYRITE_CRATES_IO_TOKEN }}


### PR DESCRIPTION
### Changes
* Re-adds trusted publishing as the crate is now published initially.
* Also updates the release-bins as it fails to trigger on main.

Related to #65 