### PR TITLE
feat: adjust workflow to trigger on workflow_run

### DIFF
--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -1,11 +1,28 @@
 name: release-binaries
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["release-crate"]
+    types: [completed]
 
 jobs:
+  get-release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+    steps:
+      - name: Get latest release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(gh release view --repo "${{ github.repository }}" --json tagName --jq '.tagName')
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
   release-binary-assets:
+    needs: get-release
     permissions:
       contents: write
     strategy:
@@ -24,14 +41,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.get-release.outputs.tag }}
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: copyrite
-#          tar: none
           target: ${{ matrix.target }}
+          ref: refs/tags/${{ needs.get-release.outputs.tag }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   release-linux-packages:
+    needs: get-release
     permissions:
       contents: write
     strategy:
@@ -45,6 +65,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.get-release.outputs.tag }}
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y rpm debhelper build-essential
       - name: Install Rust
@@ -54,6 +76,7 @@ jobs:
       - name: Release RPM assets
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.get-release.outputs.tag }}
           files: rpmbuild/RPMS/**/*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -66,4 +89,5 @@ jobs:
       - name: Release Debian assets
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.get-release.outputs.tag }}
           files: ../*.deb

--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -1,6 +1,6 @@
-copyrite (0.3.1-1) unstable; urgency=low
+copyrite (0.3.2-1) unstable; urgency=low
 
-  * Release 0.3.1
+  * Release 0.3.2
 
  -- Marko Malenic <mmalenic1@gmail.com>  Fri, 10 Apr 2026 00:00:00 +0000
 

--- a/pkg/rpm/copyrite.spec
+++ b/pkg/rpm/copyrite.spec
@@ -1,5 +1,5 @@
 Name:           copyrite
-Version:        0.3.1
+Version:        0.3.2
 Release:        1%{?dist}
 Summary:        CLI tool for efficient checksum and copy operations across object stores
 


### PR DESCRIPTION
Annoyingly the release-bins can't trigger off of `release: types:` so I'm changing it to trigger off of workflow_run, which should work.

See https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow

Related to #67 