### PR TITLE
ci: check if assets are found on release

### DIFF
--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -13,16 +13,23 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.release.outputs.tag }}
+      found: ${{ steps.release.outputs.found }}
     steps:
       - name: Get latest release tag
         id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG=$(gh release view --repo "${{ github.repository }}" --json tagName --jq '.tagName')
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          TAG=$(gh release view --repo "${{ github.repository }}" --json tagName,assets --jq 'select(.assets | length == 0) | .tagName')
+          if [ -z "$TAG" ]; then
+            echo "found=false" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+            echo "found=true" >> $GITHUB_OUTPUT
+          fi
   release-binary-assets:
     needs: get-release
+    if: ${{ needs.get-release.outputs.found == 'true' }}
     permissions:
       contents: write
     strategy:
@@ -52,6 +59,7 @@ jobs:
 
   release-linux-packages:
     needs: get-release
+    if: ${{ needs.get-release.outputs.found == 'true' }}
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
### Changes
* Check if a release has assets before running release-bins.yml.

The release-plz action runs twice, once when merging a regular PR, and then another time when merging a chore: release PR created by release-plz itself. A package release is created only in the second instance, so there needs to be a check that determines if release-bins should run, and skip otherwise.