### PR TITLE
feat: stalled stream override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,7 @@ dependencies = [
  "indicatif",
  "md-5 0.11.0",
  "parse-size",
+ "pastey",
  "rand 0.10.0",
  "serde",
  "serde_json",
@@ -2141,6 +2142,12 @@ name = "parse-size"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.15"
+version = "1.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -257,7 +257,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.103.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae64963d3d16d8070aaa2fb79c11cd3b13f44d2f13bba3fe8f49dcd2c42f2987"
+checksum = "811bcb3da8bf26e571da7a248c0a93152bba9642aa4c8c907c58d949fa5f1d5c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.97.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.99.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -381,13 +381,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "p256",
  "percent-encoding",
  "ring",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
@@ -491,7 +491,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "h2 0.3.27",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -499,12 +499,12 @@ dependencies = [
  "hyper 0.14.32",
  "hyper 1.9.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "indexmap",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.63.6",
@@ -611,11 +611,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -624,6 +625,17 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -663,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -705,9 +717,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -785,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -809,7 +821,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -850,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -873,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -897,6 +909,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "colorchoice"
@@ -959,7 +977,7 @@ dependencies = [
  "md-5 0.11.0",
  "parse-size",
  "pastey",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha1 0.11.0",
@@ -1014,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
@@ -1026,7 +1044,7 @@ checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
  "digest 0.10.7",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "rustversion",
 ]
@@ -1167,10 +1185,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.10.0"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1210,13 +1237,14 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1459,7 +1487,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1496,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1537,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1560,6 +1588,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1637,9 +1674,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1678,7 +1715,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1706,16 +1743,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -1845,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1860,7 +1896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1917,10 +1953,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1939,9 +1977,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1996,7 +2034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2287,9 +2325,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2297,13 +2335,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2336,15 +2374,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2402,7 +2440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -2465,14 +2503,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -2491,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -2510,9 +2548,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2672,7 +2710,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2694,7 +2732,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2933,9 +2971,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2974,7 +3012,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -3095,9 +3133,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -3161,9 +3199,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3214,11 +3252,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3227,14 +3265,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3245,9 +3283,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3255,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3268,9 +3306,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3311,9 +3349,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3456,6 +3494,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/copyrite/Cargo.toml
+++ b/copyrite/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 clap = { version = "4", features = ["derive", "env", "cargo", "wrap_help"] }
 thiserror = "2"
 rand = "0.10"
+pastey = "0.2"
 
 # Async
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "test-util", "io-util", "io-std", "fs"] }

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -527,6 +527,36 @@ impl CopyMode {
     }
 }
 
+/// Controls overriding the AWS SDK's stalled stream protection.
+///
+/// SSP is useful to prevent dead TCP connections from hanging if the SDK detects that no bytes are
+/// being transferred. Large objects using server-side copy can trigger this incorrectly, as
+/// `CopyObject` may not transmit many bytes for a while, which means that this should be disabled
+/// in those instances.
+#[derive(Debug, Clone, ValueEnum, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub enum StalledStreamProtection {
+    /// Use the default SDK behaviour.
+    Default,
+    /// Disable SSP only for server-side copy operations using `CopyObject` and
+    /// `UploadPartCopy`.
+    #[default]
+    DisableCopyObject,
+    /// Disable SSP for every S3 operation.
+    DisableAll,
+}
+
+impl StalledStreamProtection {
+    /// Whether SSP should be disabled for server-side copies.
+    pub fn disable_copy_object(&self) -> bool {
+        matches!(self, Self::DisableCopyObject | Self::DisableAll)
+    }
+
+    /// Whether SSP should be disabled for all requests.
+    pub fn disable_all(&self) -> bool {
+        matches!(self, Self::DisableAll)
+    }
+}
+
 /// Details of how to locate credentials or specify no credentials needed
 #[derive(Debug, Clone, ValueEnum, Copy, Default, Deserialize, Serialize)]
 pub enum CredentialProvider {
@@ -1002,6 +1032,20 @@ pub struct Compatibility {
         hide_short_help = true
     )]
     pub no_checksum_mode: bool,
+    /// Controls overriding the AWS SDK's stalled stream protection.
+    ///
+    /// SSP is useful to prevent dead TCP connections from hanging if the SDK detects that no bytes are
+    /// being transferred. Large objects using server-side copy can trigger this incorrectly, as
+    /// `CopyObject` may not transmit many bytes for a while, which means that this should be disabled
+    /// in those instances.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_STALLED_STREAM_PROTECTION",
+        default_value = "disable-copy-object",
+        hide_short_help = true
+    )]
+    pub stalled_stream_protection: StalledStreamProtection,
     #[arg(
         global = true,
         long,
@@ -1033,6 +1077,13 @@ pub struct Compatibility {
     #[arg(
         global = true,
         long,
+        env = "COPYRITE_SOURCE_STALLED_STREAM_PROTECTION",
+        hide = true
+    )]
+    pub source_stalled_stream_protection: Option<StalledStreamProtection>,
+    #[arg(
+        global = true,
+        long,
         env = "COPYRITE_DESTINATION_S3_COMPATIBLE",
         hide = true
     )]
@@ -1058,6 +1109,13 @@ pub struct Compatibility {
         hide = true
     )]
     pub destination_no_checksum_mode: bool,
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_DESTINATION_STALLED_STREAM_PROTECTION",
+        hide = true
+    )]
+    pub destination_stalled_stream_protection: Option<StalledStreamProtection>,
 }
 
 impl Compatibility {
@@ -1114,16 +1172,30 @@ impl Compatibility {
             || self.no_checksum_mode()
     }
 
+    /// The SSP configuration for the source.
+    pub fn source_stalled_stream_protection(&self) -> StalledStreamProtection {
+        self.source_stalled_stream_protection
+            .unwrap_or(self.stalled_stream_protection)
+    }
+
+    /// The SSP configuration for the destination.
+    pub fn destination_stalled_stream_protection(&self) -> StalledStreamProtection {
+        self.destination_stalled_stream_protection
+            .unwrap_or(self.stalled_stream_protection)
+    }
+
     /// Check if any source or destination options are set.
     pub fn has_prefixed_options(&self) -> bool {
         self.source_s3_compatible
             || self.source_force_path_style
             || self.source_no_get_object_attributes
             || self.source_no_checksum_mode
+            || self.source_stalled_stream_protection.is_some()
             || self.destination_s3_compatible
             || self.destination_force_path_style
             || self.destination_no_get_object_attributes
             || self.destination_no_checksum_mode
+            || self.destination_stalled_stream_protection.is_some()
     }
 }
 

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -531,16 +531,16 @@ impl CopyMode {
 ///
 /// SSP is useful to prevent dead TCP connections from hanging if the SDK detects that no bytes are
 /// being transferred. Large objects using server-side copy can trigger this incorrectly, as
-/// `CopyObject` may not transmit many bytes for a while, which means that this should be disabled
-/// in those instances.
+/// `CopyObject` may not transmit many bytes for a while. In these situations it's recommended for
+/// SSP to be disabled.
 #[derive(Debug, Clone, ValueEnum, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub enum StalledStreamProtection {
-    /// Use the default SDK behaviour.
-    Default,
     /// Disable SSP only for server-side copy operations using `CopyObject` and
     /// `UploadPartCopy`.
     #[default]
     DisableCopyObject,
+    /// Use the default SDK behaviour.
+    Default,
     /// Disable SSP for every S3 operation.
     DisableAll,
 }
@@ -1036,8 +1036,8 @@ pub struct Compatibility {
     ///
     /// SSP is useful to prevent dead TCP connections from hanging if the SDK detects that no bytes are
     /// being transferred. Large objects using server-side copy can trigger this incorrectly, as
-    /// `CopyObject` may not transmit many bytes for a while, which means that this should be disabled
-    /// in those instances.
+    /// `CopyObject` may not transmit many bytes for a while. In these situations it's recommended for
+    /// SSP to be disabled.
     #[arg(
         global = true,
         long,

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -332,17 +332,16 @@ impl S3 {
         let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
         let do_copy = |tagging, tagging_set, metadata, metadata_set, additional_checksum| async {
             self.client
-                .inner()
-                .copy_object()
-                .tagging_directive(tagging)
-                .set_tagging(tagging_set)
-                .metadata_directive(metadata)
-                .set_metadata(metadata_set)
-                .set_checksum_algorithm(additional_checksum)
-                .copy_source(Self::copy_source(&source.key, &source.bucket))
-                .key(&destination.key)
-                .bucket(&destination.bucket)
-                .send()
+                .copy_object(move |b| {
+                    b.tagging_directive(tagging)
+                        .set_tagging(tagging_set)
+                        .metadata_directive(metadata)
+                        .set_metadata(metadata_set)
+                        .set_checksum_algorithm(additional_checksum)
+                        .copy_source(Self::copy_source(&source.key, &source.bucket))
+                        .key(&destination.key)
+                        .bucket(&destination.bucket)
+                })
                 .await
         };
 
@@ -433,22 +432,23 @@ impl S3 {
         };
 
         if let Some(part_number) = multi_part.part_number {
-            let part = self
+            let part_number_i32 = i32::try_from(part_number)?;
+            let range = multi_part
+                .format_range()
+                .ok_or_else(|| Error::aws_error("invalid range".to_string()))?;
+            let response = self
                 .client
-                .inner()
-                .upload_part_copy()
-                .upload_id(&upload_id)
-                .part_number(i32::try_from(part_number)?)
-                .key(&destination.key)
-                .bucket(&destination.bucket)
-                .copy_source(Self::copy_source(&source.key, &source.bucket))
-                .copy_source_range(
-                    multi_part
-                        .format_range()
-                        .ok_or_else(|| Error::aws_error("invalid range".to_string()))?,
-                )
-                .send()
-                .await?
+                .upload_part_copy(|b| {
+                    b.upload_id(&upload_id)
+                        .part_number(part_number_i32)
+                        .key(&destination.key)
+                        .bucket(&destination.bucket)
+                        .copy_source(Self::copy_source(&source.key, &source.bucket))
+                        .copy_source_range(range)
+                })
+                .await?;
+
+            let part = response
                 .copy_part_result
                 .ok_or_else(|| Error::aws_error("missing copy part result".to_string()))?;
 
@@ -480,18 +480,13 @@ impl S3 {
             return Ok(Default::default());
         }
 
+        let range = multi_part
+            .as_ref()
+            .and_then(|multi_part| multi_part.format_range());
+
         let result = self
             .client
-            .inner()
-            .get_object()
-            .bucket(&source.bucket)
-            .key(&source.key)
-            .set_range(
-                multi_part
-                    .as_ref()
-                    .and_then(|multi_part| multi_part.format_range()),
-            )
-            .send()
+            .get_object(|b| b.bucket(&source.bucket).key(&source.key).set_range(range))
             .await?;
 
         Ok(CopyContent::new(Box::new(result.body.into_async_read())))
@@ -507,17 +502,16 @@ impl S3 {
         let buf = Self::read_content(&mut content, None).await?;
 
         let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
-        let do_put = |tags, metadata, additional_checksum, buf| async {
+        let do_put = |tags, metadata, additional_checksum, buf: Vec<u8>| async {
             self.client
-                .inner()
-                .put_object()
-                .set_tagging(tags)
-                .set_metadata(metadata)
-                .set_checksum_algorithm(additional_checksum)
-                .bucket(&destination.bucket)
-                .key(&destination.key)
-                .body(ByteStream::from(buf))
-                .send()
+                .put_object(move |b| {
+                    b.set_tagging(tags)
+                        .set_metadata(metadata)
+                        .set_checksum_algorithm(additional_checksum)
+                        .bucket(&destination.bucket)
+                        .key(&destination.key)
+                        .body(ByteStream::from(buf))
+                })
                 .await
         };
 
@@ -594,17 +588,17 @@ impl S3 {
         };
 
         if let Some(part_number) = multi_part.part_number {
+            let part_number_i32 = i32::try_from(part_number)?;
             let part = self
                 .client
-                .inner()
-                .upload_part()
-                .upload_id(&upload_id)
-                .set_checksum_algorithm(additional_checksum)
-                .part_number(i32::try_from(part_number)?)
-                .key(&destination.key)
-                .bucket(&destination.bucket)
-                .body(ByteStream::from(buf))
-                .send()
+                .upload_part(|b| {
+                    b.upload_id(&upload_id)
+                        .set_checksum_algorithm(additional_checksum)
+                        .part_number(part_number_i32)
+                        .key(&destination.key)
+                        .bucket(&destination.bucket)
+                        .body(ByteStream::from(buf))
+                })
                 .await?;
 
             let mut result: CopyResult = (part, part_number, upload_id).into();
@@ -634,7 +628,7 @@ impl S3 {
         mut parts: Vec<Part>,
     ) -> Result<()> {
         // Parts must be ordered.
-        parts.sort_by(|a, b| a.part_number.cmp(&b.part_number));
+        parts.sort_by_key(|a| a.part_number);
 
         self.client
             .inner()

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -214,13 +214,7 @@ impl S3 {
         key: &str,
         bucket: &str,
     ) -> result::Result<HeadObjectOutput, SdkError<HeadObjectError, HttpResponse>> {
-        self.client
-            .inner()
-            .head_object()
-            .bucket(bucket)
-            .key(key)
-            .send()
-            .await
+        self.client.head_object(|b| b.bucket(bucket).key(key)).await
     }
 
     /// Get the object tagging.
@@ -230,11 +224,7 @@ impl S3 {
         bucket: &str,
     ) -> result::Result<GetObjectTaggingOutput, SdkError<GetObjectTaggingError, HttpResponse>> {
         self.client
-            .inner()
-            .get_object_tagging()
-            .bucket(bucket)
-            .key(key)
-            .send()
+            .get_object_tagging(|b| b.bucket(bucket).key(key))
             .await
     }
 
@@ -266,14 +256,13 @@ impl S3 {
     ) -> Result<(String, Vec<ApiError>)> {
         let do_upload = |tagging, metadata, additional_checksum| async {
             self.client
-                .inner()
-                .create_multipart_upload()
-                .set_tagging(tagging)
-                .set_metadata(metadata)
-                .set_checksum_algorithm(additional_checksum)
-                .bucket(bucket)
-                .key(key)
-                .send()
+                .create_multipart_upload(|b| {
+                    b.set_tagging(tagging)
+                        .set_metadata(metadata)
+                        .set_checksum_algorithm(additional_checksum)
+                        .bucket(bucket)
+                        .key(key)
+                })
                 .await
         };
 
@@ -630,23 +619,21 @@ impl S3 {
         // Parts must be ordered.
         parts.sort_by_key(|a| a.part_number);
 
+        let parts = parts
+            .into_iter()
+            .map(|part| part.try_into())
+            .collect::<Result<Vec<_>>>()?;
         self.client
-            .inner()
-            .complete_multipart_upload()
-            .bucket(bucket)
-            .key(key)
-            .multipart_upload(
-                CompletedMultipartUpload::builder()
-                    .set_parts(Some(
-                        parts
-                            .into_iter()
-                            .map(|part| part.try_into())
-                            .collect::<Result<Vec<_>>>()?,
-                    ))
-                    .build(),
-            )
-            .upload_id(upload_id)
-            .send()
+            .complete_multipart_upload(|b| {
+                b.bucket(bucket)
+                    .key(key)
+                    .multipart_upload(
+                        CompletedMultipartUpload::builder()
+                            .set_parts(Some(parts))
+                            .build(),
+                    )
+                    .upload_id(upload_id)
+            })
             .await?;
 
         Ok(())

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -50,7 +50,6 @@ macro_rules! s3_wrapper_call {
                     builder.customize(),
                     self.stalled_stream_protection.$disable(),
                 )
-                .await
                 .send()
                 .await
             }
@@ -136,11 +135,6 @@ impl S3Client {
         ))
     }
 
-    /// Get the inner AWS S3 client.
-    pub fn inner(&self) -> &Arc<Client> {
-        &self.inner
-    }
-
     /// Whether to avoid `GetObjectAttributes` calls.
     pub fn no_get_object_attributes(&self) -> bool {
         self.no_get_object_attributes
@@ -157,7 +151,7 @@ impl S3Client {
     }
 
     /// Apply the SSP config override.
-    async fn ssp_override<T, E, B>(
+    fn ssp_override<T, E, B>(
         &self,
         customize: CustomizableOperation<T, E, B>,
         disable: bool,
@@ -261,6 +255,11 @@ impl S3Client {
     s3_wrapper_call!(get_object, disable_all);
     s3_wrapper_call!(put_object, disable_all);
     s3_wrapper_call!(upload_part, disable_all);
+    s3_wrapper_call!(head_object, disable_all);
+    s3_wrapper_call!(complete_multipart_upload, disable_all);
+    s3_wrapper_call!(create_multipart_upload, disable_all);
+    s3_wrapper_call!(get_object_tagging, disable_all);
+    s3_wrapper_call!(get_object_attributes, disable_all);
     s3_wrapper_call!(copy_object, disable_copy_object);
     s3_wrapper_call!(upload_part_copy, disable_copy_object);
 }

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -29,7 +29,7 @@ pub struct S3Client {
     stalled_stream_protection: StalledStreamProtection,
 }
 
-/// Generate an `S3Client` wrapper method that calls the underlying `aws-sdk-s3` operation.
+/// Generate an `S3Client` wrapper method that calls the underlying S3 operation.
 macro_rules! s3_wrapper_call {
     ($name:ident, $disable:ident) => {
         paste! {
@@ -151,12 +151,12 @@ impl S3Client {
         self.no_checksum_mode
     }
 
-    /// The stalled-stream protection mode for this client.
+    /// The SSP mode for this client.
     pub fn stalled_stream_protection(&self) -> StalledStreamProtection {
         self.stalled_stream_protection
     }
 
-    /// Apply the SSP-disabled config override to a customizable operation when `disable` is true.
+    /// Apply the SSP config override.
     async fn ssp_override<T, E, B>(
         &self,
         customize: CustomizableOperation<T, E, B>,

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -1,14 +1,20 @@
 //! Module that handles all file IO
 //!
 
-use crate::cli::{Compatibility, CredentialProvider, Credentials};
+use crate::cli::{Compatibility, CredentialProvider, Credentials, StalledStreamProtection};
 use crate::error::Error::ParseError;
 use crate::error::{Error, Result};
 use aws_config::Region;
 use aws_credential_types::provider::ProvideCredentials;
+use aws_sdk_s3::client::customize::CustomizableOperation;
+use aws_sdk_s3::config::StalledStreamProtectionConfig;
+use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::operation;
 use aws_sdk_s3::{Client, config};
 use aws_smithy_runtime_api::client::behavior_version::BehaviorVersion;
+use pastey::paste;
 use serde::Deserialize;
+use std::result;
 use std::sync::Arc;
 
 pub mod copy;
@@ -20,19 +26,65 @@ pub struct S3Client {
     inner: Arc<Client>,
     no_get_object_attributes: bool,
     no_checksum_mode: bool,
+    stalled_stream_protection: StalledStreamProtection,
+}
+
+/// Generate an `S3Client` wrapper method that calls the underlying `aws-sdk-s3` operation.
+macro_rules! s3_wrapper_call {
+    ($name:ident, $disable:ident) => {
+        paste! {
+            #[doc = concat!("A wrapper around `", stringify!($name), "` that overrides SSP and resolves the query.")]
+            pub async fn $name<F>(
+                &self,
+                configure: F,
+            ) -> result::Result<
+                operation::$name::[<$name:camel Output>],
+                SdkError<operation::$name::[<$name:camel Error>]>,
+            >
+            where
+                F: FnOnce(operation::$name::builders::[<$name:camel FluentBuilder>])
+                    -> operation::$name::builders::[<$name:camel FluentBuilder>],
+            {
+                let builder = configure(self.inner.$name());
+                self.ssp_override(
+                    builder.customize(),
+                    self.stalled_stream_protection.$disable(),
+                )
+                .await
+                .send()
+                .await
+            }
+        }
+    };
 }
 
 impl S3Client {
-    /// Create a new S3Client.
+    /// Create a new S3Client with default SSP.
     pub fn new(
         client: Arc<Client>,
         no_get_object_attributes: bool,
         no_checksum_mode: bool,
     ) -> Self {
+        Self::with_stalled_stream_protection(
+            client,
+            no_get_object_attributes,
+            no_checksum_mode,
+            StalledStreamProtection::default(),
+        )
+    }
+
+    /// Create a new S3Client with SSP mode.
+    pub fn with_stalled_stream_protection(
+        client: Arc<Client>,
+        no_get_object_attributes: bool,
+        no_checksum_mode: bool,
+        stalled_stream_protection: StalledStreamProtection,
+    ) -> Self {
         Self {
             inner: client,
             no_get_object_attributes,
             no_checksum_mode,
+            stalled_stream_protection,
         }
     }
 
@@ -51,10 +103,12 @@ impl S3Client {
             compatibility.source_force_path_style(),
         )
         .await?;
-        Ok(Self::new(
+
+        Ok(Self::with_stalled_stream_protection(
             Arc::new(client),
             compatibility.source_no_get_object_attributes(),
             compatibility.source_no_checksum_mode(),
+            compatibility.source_stalled_stream_protection(),
         ))
     }
 
@@ -73,10 +127,12 @@ impl S3Client {
             compatibility.destination_force_path_style(),
         )
         .await?;
-        Ok(Self::new(
+
+        Ok(Self::with_stalled_stream_protection(
             Arc::new(client),
             compatibility.destination_no_get_object_attributes(),
             compatibility.destination_no_checksum_mode(),
+            compatibility.destination_stalled_stream_protection(),
         ))
     }
 
@@ -93,6 +149,27 @@ impl S3Client {
     /// Whether to disable checksum mode.
     pub fn no_checksum_mode(&self) -> bool {
         self.no_checksum_mode
+    }
+
+    /// The stalled-stream protection mode for this client.
+    pub fn stalled_stream_protection(&self) -> StalledStreamProtection {
+        self.stalled_stream_protection
+    }
+
+    /// Apply the SSP-disabled config override to a customizable operation when `disable` is true.
+    async fn ssp_override<T, E, B>(
+        &self,
+        customize: CustomizableOperation<T, E, B>,
+        disable: bool,
+    ) -> CustomizableOperation<T, E, B> {
+        if disable {
+            customize.config_override(
+                config::Config::builder()
+                    .stalled_stream_protection(StalledStreamProtectionConfig::disabled()),
+            )
+        } else {
+            customize
+        }
     }
 
     /// Create an S3 client from the credentials provider, profile, region and endpoint url.
@@ -180,6 +257,12 @@ impl S3Client {
         )
         .await
     }
+
+    s3_wrapper_call!(get_object, disable_all);
+    s3_wrapper_call!(put_object, disable_all);
+    s3_wrapper_call!(upload_part, disable_all);
+    s3_wrapper_call!(copy_object, disable_copy_object);
+    s3_wrapper_call!(upload_part_copy, disable_copy_object);
 }
 
 /// The type of provider for the object.

--- a/copyrite/src/io/sums/aws.rs
+++ b/copyrite/src/io/sums/aws.rs
@@ -100,15 +100,15 @@ impl S3 {
 
     /// Get an existing sums file if it exists.
     pub async fn get_existing_sums(&self) -> Result<Option<SumsFile>> {
-        match self
+        let result = self
             .client
-            .inner()
-            .get_object()
-            .bucket(&self.bucket)
-            .key(SumsFile::format_sums_file(&self.key))
-            .send()
-            .await
-        {
+            .get_object(|b| {
+                b.bucket(&self.bucket)
+                    .key(SumsFile::format_sums_file(&self.key))
+            })
+            .await;
+
+        match result {
             Ok(sums) => {
                 let data = sums.body.collect().await?.to_vec();
                 let sums = SumsFile::read_from_slice(data.as_slice()).await?;
@@ -429,17 +429,15 @@ impl S3 {
 
     /// Get the object and convert it into an `AsyncRead`.
     pub async fn object_reader(&self) -> Result<impl AsyncRead + 'static> {
-        Ok(Box::new(
-            self.client
-                .inner()
-                .get_object()
-                .bucket(&self.bucket)
-                .key(SumsFile::format_target_file(&self.key))
-                .send()
-                .await?
-                .body
-                .into_async_read(),
-        ))
+        let response = self
+            .client
+            .get_object(|b| {
+                b.bucket(&self.bucket)
+                    .key(SumsFile::format_target_file(&self.key))
+            })
+            .await?;
+
+        Ok(Box::new(response.body.into_async_read()))
     }
 
     /// Get the object file size.
@@ -455,14 +453,14 @@ impl S3 {
     /// Write the sums file to the configured location using `PutObject`.
     pub async fn put_sums(&self, sums_file: &SumsFile) -> Result<()> {
         let key = SumsFile::format_sums_file(&self.key);
+        let body = ByteStream::from(sums_file.to_json_string()?.into_bytes());
         self.client
-            .inner()
-            .put_object()
-            .checksum_algorithm(ChecksumAlgorithm::Crc64Nvme)
-            .bucket(&self.bucket)
-            .key(&key)
-            .body(ByteStream::from(sums_file.to_json_string()?.into_bytes()))
-            .send()
+            .put_object(move |b| {
+                b.checksum_algorithm(ChecksumAlgorithm::Crc64Nvme)
+                    .bucket(&self.bucket)
+                    .key(&key)
+                    .body(body)
+            })
             .await?;
         Ok(())
     }

--- a/copyrite/src/io/sums/aws.rs
+++ b/copyrite/src/io/sums/aws.rs
@@ -131,18 +131,16 @@ impl S3 {
         if let Some(ref attributes) = self.get_object_attributes {
             return Some(attributes);
         }
-
         let attributes = self
             .client
-            .inner()
-            .get_object_attributes()
-            .bucket(&self.bucket)
-            .key(SumsFile::format_target_file(&self.key))
-            .object_attributes(ObjectAttributes::Etag)
-            .object_attributes(ObjectAttributes::Checksum)
-            .object_attributes(ObjectAttributes::ObjectSize)
-            .object_attributes(ObjectAttributes::ObjectParts)
-            .send()
+            .get_object_attributes(|b| {
+                b.bucket(&self.bucket)
+                    .key(SumsFile::format_target_file(&self.key))
+                    .object_attributes(ObjectAttributes::Etag)
+                    .object_attributes(ObjectAttributes::Checksum)
+                    .object_attributes(ObjectAttributes::ObjectSize)
+                    .object_attributes(ObjectAttributes::ObjectParts)
+            })
             .await;
 
         match attributes {
@@ -161,17 +159,20 @@ impl S3 {
             return Ok(&self.head_object[&part_number]);
         }
 
-        let mut head = self
+        let part_number_i32 = part_number.map(i32::try_from).transpose()?;
+        let head_object = self
             .client
-            .inner()
-            .head_object()
-            .bucket(&self.bucket)
-            .key(SumsFile::format_target_file(&self.key))
-            .set_part_number(part_number.map(i32::try_from).transpose()?);
-        if !self.client.no_checksum_mode() {
-            head = head.checksum_mode(ChecksumMode::Enabled);
-        }
-        let head_object = head.send().await?;
+            .head_object(|mut b| {
+                b = b
+                    .bucket(&self.bucket)
+                    .key(SumsFile::format_target_file(&self.key))
+                    .set_part_number(part_number_i32);
+                if !self.client.no_checksum_mode() {
+                    b = b.checksum_mode(ChecksumMode::Enabled);
+                }
+                b
+            })
+            .await?;
 
         Ok(self.head_object.entry(part_number).or_insert(head_object))
     }

--- a/copyrite/src/task/generate.rs
+++ b/copyrite/src/task/generate.rs
@@ -398,8 +398,8 @@ impl SumCtxPairs {
         // Get the checksum which contains the most amount of occurrences across groups of sums files.
         let file_ctx = files
             .0
-            .iter()
-            .flat_map(|(file, _)| file.0.0.checksums.keys().cloned())
+            .keys()
+            .flat_map(|file| file.0.0.checksums.keys().cloned())
             .fold(BTreeMap::new(), |mut map, val| {
                 // Count occurrences
                 map.entry(val).and_modify(|count| *count += 1).or_insert(1);


### PR DESCRIPTION
The AWS has a feature called stalled stream protection, which will cause a request to error when the SDK detects that no bytes are being transmitted. This feature is useful to avoid hanging TCP connections that are kept alive for longer than they should be. However, in some cases, it results in a false positive, which aborts the connection even though it is valid.

These cases tend to occur with `CopyObject` or `UploadPartCopy` because the SDK transmits a small amount of data to initiate the request, and the actual copy occurs on the server-side. This results in no bytes being detected, and the connection being stopped, even though the copy object would have succeeded on the server side. E.g. see https://github.com/awslabs/aws-sdk-rust/issues/1141.

This PR adds an override flag that lets the user disable this. By default, SSP is disabled for `CopyObject` and `UploadPartCopy` and remains enabled for other requests. There is also the option to disable it completely, or use the SDK's default (which is to have it enabled).