### PR TITLE
fix: in-memory bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,15 +139,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.16"
+version = "1.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -155,16 +155,17 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "sha1 0.10.6",
  "time",
  "tokio",
@@ -187,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -197,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -209,15 +210,15 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -226,7 +227,7 @@ dependencies = [
  "bytes-utils",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
@@ -237,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.119.0"
+version = "1.133.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
+checksum = "237aba2985e3c0a83e199cc7aa9a64a16c599875bc98170f00932f6199f19922"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -247,8 +248,9 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json 0.61.9",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -257,29 +259,29 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.104.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811bcb3da8bf26e571da7a248c0a93152bba9642aa4c8c907c58d949fa5f1d5c"
+checksum = "1c4e56ac810211dc33810c7aa3612eda29a8b1e8c7e2db6e960c8657e3d95e42"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -288,22 +290,22 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.98.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -312,22 +314,22 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.100.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -336,22 +338,22 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.103.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -361,32 +363,31 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "p256",
  "percent-encoding",
- "ring",
  "sha2 0.11.0",
  "subtle",
  "time",
@@ -407,21 +408,22 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.12"
+version = "0.64.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
 dependencies = [
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
  "hex",
- "http 0.2.12",
- "http-body 0.4.6",
- "md-5 0.10.6",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "md-5",
  "pin-project-lite",
- "sha1 0.10.6",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "tracing",
 ]
 
@@ -438,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.6"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -449,28 +451,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.63.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -493,7 +474,7 @@ dependencies = [
  "h2 0.3.27",
  "h2 0.4.14",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "hyper 0.14.32",
@@ -517,19 +498,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.9"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.62.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
-dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -542,7 +516,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -585,20 +559,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -611,16 +586,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -639,17 +614,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-schema"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.1",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -675,13 +661,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -689,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -750,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -972,12 +959,14 @@ dependencies = [
  "envy",
  "futures-util",
  "hex",
+ "http-body 1.0.1",
+ "http-body-util",
  "humantime",
  "indicatif",
- "md-5 0.11.0",
+ "md-5",
  "parse-size",
  "pastey",
- "rand 0.10.1",
+ "rand",
  "serde",
  "serde_json",
  "sha1 0.11.0",
@@ -985,6 +974,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1038,15 +1028,12 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
-version = "1.6.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "crc",
  "digest 0.10.7",
- "rand 0.9.4",
- "regex",
- "rustversion",
+ "spin",
 ]
 
 [[package]]
@@ -1145,24 +1132,14 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1177,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1201,11 +1178,12 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1231,6 +1209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1243,7 +1222,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1278,35 +1257,37 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.4.9",
- "der",
+ "crypto-bigint",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1353,9 +1334,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1378,6 +1359,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1453,6 +1440,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1494,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -1533,7 +1521,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1558,9 +1546,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1612,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1638,7 +1635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -1649,7 +1646,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1716,7 +1713,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -1747,7 +1744,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "hyper 1.9.0",
  "hyper-util",
  "rustls 0.23.40",
@@ -1767,7 +1764,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "hyper 1.9.0",
  "ipnet",
@@ -1953,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1995,17 +1992,17 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2015,16 +2012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
-]
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -2039,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "minimal-lexical"
@@ -2091,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2156,12 +2143,13 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -2183,9 +2171,18 @@ checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2207,9 +2204,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -2265,15 +2262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2279,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2325,16 +2322,6 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
@@ -2345,31 +2332,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2435,13 +2403,12 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint 0.4.9",
  "hmac 0.12.1",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -2600,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -2679,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2762,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -2803,10 +2770,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.6.0"
+name = "spin"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -3270,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3283,9 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3293,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3306,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3349,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3643,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "base64",
+ "bytes",
  "clap",
  "console",
  "crc32c",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.133.0"
+version = "1.134.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237aba2985e3c0a83e199cc7aa9a64a16c599875bc98170f00932f6199f19922"
+checksum = "be06bdfdf00371318253d74776567512d1229d1f3cd5546d27d333c89e013b84"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -273,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.105.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4e56ac810211dc33810c7aa3612eda29a8b1e8c7e2db6e960c8657e3d95e42"
+checksum = "8b6fa2aa029a7298bc3d863c253fe6745dac677620f20c337b6ca7cc208f7201"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -297,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.99.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
+checksum = "bee2719d4a5e5e147bb9e9b77490df6ece750df1094968aa857b09b618a1881a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -321,10 +330,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.101.0"
+version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
+checksum = "b30d254992d56ef19f430396e5765b11e0f5bd21a7a557cb12fca1c8c18b9636"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -345,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.104.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
+checksum = "59f4f8065fe615dbed9096458ba98dda6d641553ffd5aedd27e37e65211aca9f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -462,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -478,7 +488,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "hyper 0.14.32",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -498,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -586,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -626,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -784,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -899,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -944,6 +954,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "aws-sdk-secretsmanager",
+ "aws-smithy-async",
  "aws-smithy-mocks",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1229,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1705,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1746,7 +1757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls 0.23.40",
  "rustls-native-certs",
@@ -1767,12 +1778,12 @@ dependencies = [
  "futures-util",
  "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2039,9 +2050,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2485,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2714,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2762,9 +2773,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2954,7 +2965,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3107,9 +3118,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -3173,9 +3184,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3597,18 +3608,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/copyrite/Cargo.toml
+++ b/copyrite/Cargo.toml
@@ -60,6 +60,7 @@ envy = "0.4"
 dotenvy = "0.15"
 
 aws-smithy-mocks = "0.2"
+aws-smithy-async = { version = "1", features = ["rt-tokio"] }
 
 [[bench]]
 name = "generate"

--- a/copyrite/Cargo.toml
+++ b/copyrite/Cargo.toml
@@ -20,6 +20,7 @@ futures-util = "0.3"
 async-stream = "0.3"
 async-trait = "0.1"
 dyn-clone = "1"
+bytes = "1"
 http-body = "1"
 http-body-util = "0.1"
 

--- a/copyrite/Cargo.toml
+++ b/copyrite/Cargo.toml
@@ -15,10 +15,13 @@ pastey = "0.2"
 
 # Async
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "test-util", "io-util", "io-std", "fs"] }
+tokio-util = { version = "0.7", features = ["io"] }
 futures-util = "0.3"
 async-stream = "0.3"
 async-trait = "0.1"
-dyn-clone = "1.0"
+dyn-clone = "1"
+http-body = "1"
+http-body-util = "0.1"
 
 # Checksums
 md-5 = "0.11"

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -9,6 +9,7 @@ use crate::io::S3Client;
 use crate::io::copy::{CopyContent, CopyResult, CopyState, MultiPartOptions, ObjectCopy, Part};
 use aws_sdk_s3::operation::get_object_tagging::{GetObjectTaggingError, GetObjectTaggingOutput};
 use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
+use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
 use aws_sdk_s3::operation::upload_part::UploadPartOutput;
 use aws_sdk_s3::types::{
     ChecksumAlgorithm, CompletedMultipartUpload, CompletedPart, CopyPartResult, MetadataDirective,
@@ -16,10 +17,15 @@ use aws_sdk_s3::types::{
 };
 use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use aws_smithy_runtime_api::client::result::SdkError;
+use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::byte_stream::ByteStream;
+use futures_util::TryStreamExt;
+use http_body::Frame;
+use http_body_util::StreamBody;
 use std::collections::HashMap;
 use std::result;
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio_util::io::ReaderStream;
 
 /// Build an S3 sums object.
 #[derive(Debug, Default)]
@@ -481,74 +487,122 @@ impl S3 {
         Ok(CopyContent::new(Box::new(result.body.into_async_read())))
     }
 
-    /// Put the object to S3.
-    pub async fn put_object(
+    /// Wrap an async reader into a `ByteStream` that streams its contents lazily.
+    fn stream_body(reader: Box<dyn AsyncRead + Sync + Send + Unpin>) -> ByteStream {
+        let stream = ReaderStream::new(reader).map_ok(Frame::data);
+        ByteStream::new(SdkBody::from_body_1_x(StreamBody::new(stream)))
+    }
+
+    /// Put the object to S3 by streaming the content directly to the destination.
+    pub async fn put_object(&self, content: CopyContent, state: &CopyState) -> Result<CopyResult> {
+        // Best effort tagging needs to reissue the upload without tags.
+        if self.tag_mode.is_best_effort() {
+            return self.put_object_best_effort(content, state).await;
+        }
+
+        let destination = self.get_destination()?;
+        self.send_put_object(
+            content.data,
+            state.tags(),
+            state.metadata(),
+            state.additional_ctx().map(ChecksumAlgorithm::from),
+            i64::try_from(state.size())?,
+            destination.bucket.clone(),
+            destination.key.clone(),
+        )
+        .await?;
+
+        CopyResult::new(None, None, state.size(), vec![])
+    }
+
+    /// Send a streaming `PutObject` request.
+    #[allow(clippy::too_many_arguments)]
+    async fn send_put_object(
         &self,
-        mut content: CopyContent,
+        reader: Box<dyn AsyncRead + Sync + Send + Unpin>,
+        tags: Option<String>,
+        metadata: Option<HashMap<String, String>>,
+        additional_checksum: Option<ChecksumAlgorithm>,
+        content_length: i64,
+        bucket: String,
+        key: String,
+    ) -> result::Result<PutObjectOutput, SdkError<PutObjectError, HttpResponse>> {
+        let body = Self::stream_body(reader);
+        self.client
+            .put_object(move |b| {
+                b.set_tagging(tags)
+                    .set_metadata(metadata)
+                    .set_checksum_algorithm(additional_checksum)
+                    .content_length(content_length)
+                    .bucket(bucket)
+                    .key(key)
+                    .body(body)
+            })
+            .await
+    }
+
+    /// Put the object to S3 for best effort tagging. This will take into account access denied
+    /// errors and re-try if needed.
+    async fn put_object_best_effort(
+        &self,
+        content: CopyContent,
         state: &CopyState,
     ) -> Result<CopyResult> {
         let destination = self.get_destination()?;
-        let buf = Self::read_content(&mut content, None).await?;
-
         let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
-        let do_put = |tags, metadata, additional_checksum, buf: Vec<u8>| async {
-            self.client
-                .put_object(move |b| {
-                    b.set_tagging(tags)
-                        .set_metadata(metadata)
-                        .set_checksum_algorithm(additional_checksum)
-                        .bucket(&destination.bucket)
-                        .key(&destination.key)
-                        .body(ByteStream::from(buf))
-                })
-                .await
+        let content_length = i64::try_from(state.size())?;
+
+        let result = self
+            .send_put_object(
+                content.data,
+                state.tags(),
+                state.metadata().clone(),
+                additional_checksum.clone(),
+                content_length,
+                destination.bucket.clone(),
+                destination.key.clone(),
+            )
+            .await;
+
+        let err = match result {
+            Ok(_) => return CopyResult::new(None, None, state.size(), vec![]),
+            Err(err) => err,
         };
 
-        let result = do_put(
-            state.tags(),
-            state.metadata(),
-            additional_checksum.clone(),
-            buf.clone(),
+        // Only retry without tags on access denied.
+        let api_error = ApiError::from(&err);
+        let Some(reopen) = content.reopen.filter(|_| api_error.is_access_denied()) else {
+            return Err(err.into());
+        };
+
+        let content = reopen().await?;
+        self.send_put_object(
+            content.data,
+            None,
+            state.metadata.clone(),
+            additional_checksum,
+            content_length,
+            destination.bucket.clone(),
+            destination.key.clone(),
         )
-        .await;
+        .await?;
 
-        // Retry if this is a best effort copy and the error was access denied.
-        let (_, err) = if let Err(ref err) = result {
-            let err = ApiError::from(err);
-            if self.tag_mode.is_best_effort() && err.is_access_denied() {
-                let result = do_put(None, state.metadata(), additional_checksum, buf).await?;
-
-                (result, vec![err])
-            } else {
-                (result?, vec![])
-            }
-        } else {
-            (result?, vec![])
-        };
-
-        CopyResult::new(None, None, state.size(), err)
+        CopyResult::new(None, None, state.size(), vec![api_error])
     }
 
-    /// Read the copy content into a buffer.
+    /// Read the copy content for a multipart upload into a buffer.
     async fn read_content(
         content: &mut CopyContent,
-        multi_part: Option<&MultiPartOptions>,
+        multi_part: &MultiPartOptions,
     ) -> Result<Vec<u8>> {
-        if let Some(multi_part) = multi_part {
-            if multi_part.part_number.is_none() {
-                return Ok(Vec::new());
-            }
-
-            let mut buf = vec![0; usize::try_from(multi_part.bytes_transferred())?];
-            content.data.read_exact(&mut buf).await?;
-
-            Ok(buf)
-        } else {
-            let mut buf = vec![];
-            content.data.read_to_end(&mut buf).await?;
-
-            Ok(buf)
+        if multi_part.part_number.is_none() {
+            return Ok(Vec::new());
         }
+
+        let mut buf = vec![0; usize::try_from(multi_part.bytes_transferred())?];
+        content.data.read_exact(&mut buf).await?;
+
+        Ok(buf)
     }
 
     /// Upload objects using multi part uploads.
@@ -559,7 +613,7 @@ impl S3 {
         state: &CopyState,
     ) -> Result<CopyResult> {
         let destination = self.get_destination()?;
-        let buf = Self::read_content(&mut content, Some(&multi_part)).await?;
+        let buf = Self::read_content(&mut content, &multi_part).await?;
 
         let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
         // Create the upload id if it doesn't exist or use the existing one.

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -24,7 +24,7 @@ use http_body::Frame;
 use http_body_util::StreamBody;
 use std::collections::HashMap;
 use std::result;
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::io::AsyncRead;
 use tokio_util::io::ReaderStream;
 
 /// Build an S3 sums object.
@@ -590,30 +590,14 @@ impl S3 {
         CopyResult::new(None, None, state.size(), vec![api_error])
     }
 
-    /// Read the copy content for a multipart upload into a buffer.
-    async fn read_content(
-        content: &mut CopyContent,
-        multi_part: &MultiPartOptions,
-    ) -> Result<Vec<u8>> {
-        if multi_part.part_number.is_none() {
-            return Ok(Vec::new());
-        }
-
-        let mut buf = vec![0; usize::try_from(multi_part.bytes_transferred())?];
-        content.data.read_exact(&mut buf).await?;
-
-        Ok(buf)
-    }
-
     /// Upload objects using multi part uploads.
     pub async fn put_object_multipart(
         &self,
-        mut content: CopyContent,
+        content: CopyContent,
         multi_part: MultiPartOptions,
         state: &CopyState,
     ) -> Result<CopyResult> {
         let destination = self.get_destination()?;
-        let buf = Self::read_content(&mut content, &multi_part).await?;
 
         let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
         // Create the upload id if it doesn't exist or use the existing one.
@@ -632,15 +616,17 @@ impl S3 {
 
         if let Some(part_number) = multi_part.part_number {
             let part_number_i32 = i32::try_from(part_number)?;
+            let content_length = i64::try_from(multi_part.bytes_transferred())?;
             let part = self
                 .client
                 .upload_part(|b| {
                     b.upload_id(&upload_id)
                         .set_checksum_algorithm(additional_checksum)
+                        .content_length(content_length)
                         .part_number(part_number_i32)
                         .key(&destination.key)
                         .bucket(&destination.bucket)
-                        .body(ByteStream::from(buf))
+                        .body(Self::stream_body(content.data))
                 })
                 .await?;
 

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -22,6 +22,7 @@ use aws_smithy_runtime_api::client::result::SdkError;
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::byte_stream::ByteStream;
 use bytes::Bytes;
+use futures_util::stream::poll_fn;
 use futures_util::{StreamExt, TryStreamExt};
 use http_body::Frame;
 use http_body_util::StreamBody;
@@ -31,7 +32,6 @@ use std::io;
 use std::pin::Pin;
 use std::result;
 use std::sync::{Arc, Mutex};
-use futures_util::stream::poll_fn;
 use tokio::io::AsyncRead;
 use tokio::sync::mpsc;
 use tokio_util::io::ReaderStream;
@@ -517,7 +517,8 @@ impl S3 {
 
     /// Wrap an async reader into an `SdkBody`.
     fn reader_body(reader: Box<dyn AsyncRead + Sync + Send + Unpin>) -> SdkBody {
-        let stream = ReaderStream::with_capacity(reader, READER_STREAM_CAPACITY).map_ok(Frame::data);
+        let stream =
+            ReaderStream::with_capacity(reader, READER_STREAM_CAPACITY).map_ok(Frame::data);
         SdkBody::from_body_1_x(StreamBody::new(stream))
     }
 
@@ -529,7 +530,8 @@ impl S3 {
         tokio::spawn(async move {
             match (*reopen)().await {
                 Ok(content) => {
-                    let mut stream = ReaderStream::with_capacity(content.data, READER_STREAM_CAPACITY);
+                    let mut stream =
+                        ReaderStream::with_capacity(content.data, READER_STREAM_CAPACITY);
                     while let Some(chunk) = stream.next().await {
                         if tx.send(chunk).await.is_err() {
                             break;
@@ -798,5 +800,252 @@ impl ObjectCopy for S3 {
 
         self.initialize_state(source.key.to_string(), source.bucket.to_string())
             .await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::io::copy::CopyContent;
+    use aws_sdk_s3::Client;
+    use aws_sdk_s3::config::SharedAsyncSleep;
+    use aws_sdk_s3::config::retry::RetryConfig;
+    use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
+    use aws_sdk_s3::operation::get_object::GetObjectOutput;
+    use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
+    use aws_sdk_s3::operation::upload_part::UploadPartOutput;
+    use aws_smithy_async::rt::sleep::TokioSleep;
+    use aws_smithy_mocks::{MockResponseInterceptor, Rule, RuleMode, mock};
+    use aws_smithy_types::byte_stream::ByteStream;
+    use aws_smithy_types::error::ErrorMetadata;
+    use std::sync::Arc;
+    use tokio::io::AsyncReadExt;
+
+    const BUCKET: &str = "bucket";
+    const KEY: &str = "key";
+    const BODY: &[u8] = b"test";
+
+    /// Build a mock client that enables real retries with backoff so the SDK retry layer actually
+    /// re-drives the request body through the reopen factory.
+    fn retrying_mock_client(rules: &[&Rule]) -> Client {
+        let mut interceptor = MockResponseInterceptor::new().rule_mode(RuleMode::MatchAny);
+        for rule in rules {
+            interceptor = interceptor.with_rule(rule);
+        }
+
+        Client::from_conf(
+            aws_sdk_s3::config::Config::builder()
+                .with_test_defaults_v2()
+                .http_client(aws_smithy_mocks::create_mock_http_client())
+                .sleep_impl(SharedAsyncSleep::new(TokioSleep::new()))
+                .retry_config(RetryConfig::standard().with_max_attempts(3))
+                .interceptor(interceptor)
+                .build(),
+        )
+    }
+
+    /// A `get_object` rule that streams the test body.
+    fn get_object_rule() -> Rule {
+        mock!(Client::get_object)
+            .match_requests(|req| req.bucket() == Some(BUCKET) && req.key() == Some(KEY))
+            .sequence()
+            .output(|| {
+                GetObjectOutput::builder()
+                    .body(ByteStream::from_static(BODY))
+                    .build()
+            })
+            .repeatedly()
+            .build()
+    }
+
+    /// Build an S3 source from a mock client.
+    fn s3_source(client: Client) -> S3 {
+        S3Builder::default()
+            .with_client(S3Client::new(Arc::new(client), false, false))
+            .with_source(BUCKET, KEY)
+            .build()
+            .unwrap()
+    }
+
+    /// Build an S3 destination from a mock client.
+    fn s3_destination(client: Client, tag_mode: MetadataCopy) -> S3 {
+        S3Builder::default()
+            .with_client(S3Client::new(Arc::new(client), false, false))
+            .with_copy_tags(tag_mode)
+            .with_destination(BUCKET, KEY)
+            .build()
+            .unwrap()
+    }
+
+    /// Test copy state.
+    fn copy_state() -> CopyState {
+        CopyState::new(BODY.len() as u64, Some("tag=value".to_string()), None)
+    }
+
+    /// Download the mock source.
+    async fn download<F, Fut>(get_object: &Rule, upload: F) -> Result<CopyResult>
+    where
+        F: FnOnce(CopyContent) -> Fut,
+        Fut: Future<Output = Result<CopyResult>>,
+    {
+        let source = s3_source(retrying_mock_client(&[get_object]));
+        let content = source.download(None).await?;
+        upload(content).await
+    }
+
+    /// Download the mock source then upload to a copy mode destination backed by `put_object`.
+    async fn test_download(get_object: &Rule, put_object: &Rule) -> Result<CopyResult> {
+        download(get_object, |content| {
+            let destination =
+                s3_destination(retrying_mock_client(&[put_object]), MetadataCopy::Copy);
+            async move { destination.put_object(content, &copy_state()).await }
+        })
+        .await
+    }
+
+    /// A `put_object` rule that returns 503 `failures` times and then succeeds.
+    fn test_put_object(failures: usize) -> Rule {
+        mock!(Client::put_object)
+            .match_requests(|req| req.bucket() == Some(BUCKET) && req.key() == Some(KEY))
+            .sequence()
+            .http_status(503, None)
+            .times(failures)
+            .output(|| PutObjectOutput::builder().build())
+            .build()
+    }
+
+    /// A `put_object` rule that always returns 503.
+    fn test_put_object_failing() -> Rule {
+        mock!(Client::put_object)
+            .match_requests(|req| req.bucket() == Some(BUCKET) && req.key() == Some(KEY))
+            .sequence()
+            .http_status(503, None)
+            .repeatedly()
+            .build()
+    }
+
+    #[tokio::test]
+    async fn put_object_retries() {
+        let get_object = get_object_rule();
+        let put_object = test_put_object(2);
+
+        let result = test_download(&get_object, &put_object).await;
+        assert!(result.is_ok());
+        assert_eq!(put_object.num_calls(), 3);
+    }
+
+    #[tokio::test]
+    async fn put_object_retries_exceeded() {
+        let get_object = get_object_rule();
+        let put_object = test_put_object_failing();
+
+        let result = test_download(&get_object, &put_object).await;
+        assert!(result.is_err());
+        assert_eq!(put_object.num_calls(), 3);
+    }
+
+    #[tokio::test]
+    async fn put_object_best_effort() {
+        let get_object = get_object_rule();
+        let put_object = mock!(Client::put_object)
+            .match_requests(|req| req.bucket() == Some(BUCKET) && req.key() == Some(KEY))
+            .sequence()
+            .error(|| {
+                PutObjectError::generic(ErrorMetadata::builder().code("AccessDenied").build())
+            })
+            .output(|| PutObjectOutput::builder().build())
+            .build();
+
+        let result = download(&get_object, |content| {
+            let destination = s3_destination(
+                retrying_mock_client(&[&put_object]),
+                MetadataCopy::BestEffort,
+            );
+            async move { destination.put_object(content, &copy_state()).await }
+        })
+        .await
+        .unwrap();
+        assert_eq!(put_object.num_calls(), 2);
+        assert_eq!(result.api_errors.len(), 1);
+        assert!(result.api_errors[0].is_access_denied());
+    }
+
+    #[tokio::test]
+    async fn put_object_best_effort_propagates() {
+        let get_object = get_object_rule();
+        let put_object = mock!(Client::put_object)
+            .match_requests(|req| req.bucket() == Some(BUCKET) && req.key() == Some(KEY))
+            .sequence()
+            .error(|| {
+                PutObjectError::generic(ErrorMetadata::builder().code("InvalidRequest").build())
+            })
+            .repeatedly()
+            .build();
+
+        let result = download(&get_object, |content| {
+            let destination = s3_destination(
+                retrying_mock_client(&[&put_object]),
+                MetadataCopy::BestEffort,
+            );
+            async move { destination.put_object(content, &copy_state()).await }
+        })
+        .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn upload_part_retries_transient_error() {
+        let get_object = get_object_rule();
+        let create = mock!(Client::create_multipart_upload)
+            .match_requests(|req| req.bucket() == Some(BUCKET) && req.key() == Some(KEY))
+            .sequence()
+            .output(|| {
+                CreateMultipartUploadOutput::builder()
+                    .upload_id("upload-id")
+                    .build()
+            })
+            .repeatedly()
+            .build();
+        let upload_part = mock!(Client::upload_part)
+            .match_requests(|req| req.bucket() == Some(BUCKET) && req.key() == Some(KEY))
+            .sequence()
+            .http_status(503, None)
+            .times(2)
+            .output(|| UploadPartOutput::builder().e_tag("etag").build())
+            .build();
+
+        let source = s3_source(retrying_mock_client(&[&get_object]));
+        let options = MultiPartOptions {
+            part_number: Some(1),
+            start: 0,
+            end: BODY.len() as u64,
+            ..Default::default()
+        };
+        let content = source.download(Some(options.clone())).await.unwrap();
+
+        let destination = s3_destination(
+            retrying_mock_client(&[&create, &upload_part]),
+            MetadataCopy::Copy,
+        );
+        let result = destination
+            .put_object_multipart(content, options, &copy_state())
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(upload_part.num_calls(), 3);
+    }
+
+    #[tokio::test]
+    async fn reopen_reproduces_source() {
+        let get_object = get_object_rule();
+        let source = s3_source(retrying_mock_client(&[&get_object]));
+
+        let content = source.download(None).await.unwrap();
+        let mut reopened = (content.reopen)().await.unwrap();
+
+        let mut buf = Vec::new();
+        reopened.data.read_to_end(buf.as_mut()).await.unwrap();
+        assert_eq!(buf, BODY);
     }
 }

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -6,7 +6,9 @@ use crate::cli::MetadataCopy;
 use crate::error::Error::{CopyError, ParseError};
 use crate::error::{ApiError, Error, Result};
 use crate::io::S3Client;
-use crate::io::copy::{CopyContent, CopyResult, CopyState, MultiPartOptions, ObjectCopy, Part};
+use crate::io::copy::{
+    CopyContent, CopyResult, CopyState, MultiPartOptions, ObjectCopy, Part, Reopen,
+};
 use aws_sdk_s3::operation::get_object_tagging::{GetObjectTaggingError, GetObjectTaggingOutput};
 use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
 use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
@@ -19,13 +21,26 @@ use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use aws_smithy_runtime_api::client::result::SdkError;
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::byte_stream::ByteStream;
-use futures_util::TryStreamExt;
+use bytes::Bytes;
+use futures_util::{StreamExt, TryStreamExt};
 use http_body::Frame;
 use http_body_util::StreamBody;
 use std::collections::HashMap;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
 use std::result;
+use std::sync::{Arc, Mutex};
+use futures_util::stream::poll_fn;
 use tokio::io::AsyncRead;
+use tokio::sync::mpsc;
 use tokio_util::io::ReaderStream;
+
+/// The number of chunks buffered when re-trying an SDK body.
+const REOPEN_CHANNEL_CAPACITY: usize = 16;
+
+/// The read buffer capacity used when streaming a reader into an upload body.
+const READER_STREAM_CAPACITY: usize = 64 * 1024;
 
 /// Build an S3 sums object.
 #[derive(Debug, Default)]
@@ -465,14 +480,15 @@ impl S3 {
         }
     }
 
-    /// Get the object from S3.
+    /// Get the object from S3. The returned content carries a reopen function that re-issues the
+    /// same ranged get.
     pub async fn get_object(&self, multi_part: Option<MultiPartOptions>) -> Result<CopyContent> {
         let source = self.get_source()?;
 
         if let Some(multipart) = &multi_part
             && multipart.part_number.is_none()
         {
-            return Ok(Default::default());
+            return Ok(CopyContent::empty());
         }
 
         let range = multi_part
@@ -484,13 +500,69 @@ impl S3 {
             .get_object(|b| b.bucket(&source.bucket).key(&source.key).set_range(range))
             .await?;
 
-        Ok(CopyContent::new(Box::new(result.body.into_async_read())))
+        let self_clone = self.clone();
+        CopyContent::builder(Box::new(result.body.into_async_read()))
+            .with_reopen(move || self_clone.reopen_get(multi_part.clone()))
+            .build()
     }
 
-    /// Wrap an async reader into a `ByteStream` that streams its contents lazily.
-    fn stream_body(reader: Box<dyn AsyncRead + Sync + Send + Unpin>) -> ByteStream {
-        let stream = ReaderStream::new(reader).map_ok(Frame::data);
-        ByteStream::new(SdkBody::from_body_1_x(StreamBody::new(stream)))
+    /// Re-derive the object stream from the source.
+    fn reopen_get(
+        &self,
+        multi_part: Option<MultiPartOptions>,
+    ) -> Pin<Box<dyn Future<Output = Result<CopyContent>> + Send>> {
+        let self_clone = self.clone();
+        Box::pin(async move { self_clone.get_object(multi_part).await })
+    }
+
+    /// Wrap an async reader into an `SdkBody`.
+    fn reader_body(reader: Box<dyn AsyncRead + Sync + Send + Unpin>) -> SdkBody {
+        let stream = ReaderStream::with_capacity(reader, READER_STREAM_CAPACITY).map_ok(Frame::data);
+        SdkBody::from_body_1_x(StreamBody::new(stream))
+    }
+
+    /// Build a streaming `SdkBody` that re-tries its data from the source. This allows the SDK body
+    /// to be re-tried automatically when needed.
+    fn reopen_body(reopen: Arc<Reopen>) -> SdkBody {
+        let (tx, mut rx) =
+            mpsc::channel::<result::Result<Bytes, io::Error>>(REOPEN_CHANNEL_CAPACITY);
+        tokio::spawn(async move {
+            match (*reopen)().await {
+                Ok(content) => {
+                    let mut stream = ReaderStream::with_capacity(content.data, READER_STREAM_CAPACITY);
+                    while let Some(chunk) = stream.next().await {
+                        if tx.send(chunk).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Err(err) => {
+                    let _ = tx.send(Err(io::Error::other(err.to_string()))).await;
+                }
+            }
+        });
+
+        let stream = poll_fn(move |cx| rx.poll_recv(cx)).map_ok(Frame::data);
+        SdkBody::from_body_1_x(StreamBody::new(stream))
+    }
+
+    /// Build a retryable streaming `ByteStream`.
+    fn retryable_body(
+        initial: Option<Box<dyn AsyncRead + Sync + Send + Unpin>>,
+        reopen: Arc<Reopen>,
+    ) -> ByteStream {
+        let initial = Mutex::new(initial);
+        ByteStream::new(SdkBody::retryable(move || {
+            match initial.lock().unwrap_or_else(|err| err.into_inner()).take() {
+                Some(reader) => Self::reader_body(reader),
+                None => Self::reopen_body(Arc::clone(&reopen)),
+            }
+        }))
+    }
+
+    /// Build the retryable upload body for a copy content.
+    fn upload_body(content: CopyContent) -> ByteStream {
+        Self::retryable_body(Some(content.data), Arc::new(content.reopen))
     }
 
     /// Put the object to S3 by streaming the content directly to the destination.
@@ -502,32 +574,30 @@ impl S3 {
 
         let destination = self.get_destination()?;
         self.send_put_object(
-            content.data,
+            destination,
+            Self::upload_body(content),
             state.tags(),
             state.metadata(),
             state.additional_ctx().map(ChecksumAlgorithm::from),
             i64::try_from(state.size())?,
-            destination.bucket.clone(),
-            destination.key.clone(),
         )
         .await?;
 
         CopyResult::new(None, None, state.size(), vec![])
     }
 
-    /// Send a streaming `PutObject` request.
-    #[allow(clippy::too_many_arguments)]
+    /// Send a streaming `PutObject` request to the destination.
     async fn send_put_object(
         &self,
-        reader: Box<dyn AsyncRead + Sync + Send + Unpin>,
+        destination: &BucketKey,
+        body: ByteStream,
         tags: Option<String>,
         metadata: Option<HashMap<String, String>>,
         additional_checksum: Option<ChecksumAlgorithm>,
         content_length: i64,
-        bucket: String,
-        key: String,
     ) -> result::Result<PutObjectOutput, SdkError<PutObjectError, HttpResponse>> {
-        let body = Self::stream_body(reader);
+        let bucket = destination.bucket.clone();
+        let key = destination.key.clone();
         self.client
             .put_object(move |b| {
                 b.set_tagging(tags)
@@ -552,15 +622,17 @@ impl S3 {
         let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
         let content_length = i64::try_from(state.size())?;
 
+        let CopyContent { data, reopen } = content;
+        let reopen = Arc::new(reopen);
+
         let result = self
             .send_put_object(
-                content.data,
+                destination,
+                Self::retryable_body(Some(data), Arc::clone(&reopen)),
                 state.tags(),
-                state.metadata().clone(),
+                state.metadata(),
                 additional_checksum.clone(),
                 content_length,
-                destination.bucket.clone(),
-                destination.key.clone(),
             )
             .await;
 
@@ -571,19 +643,17 @@ impl S3 {
 
         // Only retry without tags on access denied.
         let api_error = ApiError::from(&err);
-        let Some(reopen) = content.reopen.filter(|_| api_error.is_access_denied()) else {
+        if !api_error.is_access_denied() {
             return Err(err.into());
-        };
+        }
 
-        let content = reopen().await?;
         self.send_put_object(
-            content.data,
+            destination,
+            Self::retryable_body(None, reopen),
             None,
-            state.metadata.clone(),
+            state.metadata(),
             additional_checksum,
             content_length,
-            destination.bucket.clone(),
-            destination.key.clone(),
         )
         .await?;
 
@@ -626,7 +696,7 @@ impl S3 {
                         .part_number(part_number_i32)
                         .key(&destination.key)
                         .bucket(&destination.bucket)
-                        .body(Self::stream_body(content.data))
+                        .body(Self::upload_body(content))
                 })
                 .await?;
 
@@ -695,7 +765,7 @@ impl ObjectCopy for S3 {
     }
 
     async fn download(&self, multi_part: Option<MultiPartOptions>) -> Result<CopyContent> {
-        Ok(self.get_object(multi_part).await?)
+        self.get_object(multi_part).await
     }
 
     async fn upload(

--- a/copyrite/src/io/copy/file.rs
+++ b/copyrite/src/io/copy/file.rs
@@ -5,7 +5,9 @@ use crate::checksum::file::SumsFile;
 use crate::error::Error::CopyError;
 use crate::error::Result;
 use crate::io::copy::{CopyContent, CopyResult, CopyState, MultiPartOptions, ObjectCopy};
+use std::future::Future;
 use std::io::SeekFrom;
+use std::pin::Pin;
 use tokio::fs::copy;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt};
 use tokio::{fs, io};
@@ -70,13 +72,14 @@ impl File {
         Ok(copy(&self.get_source()?, self.get_destination()?).await?)
     }
 
-    /// Read the source into memory.
+    /// Read the source into memory. The returned content carries a reopen factory that re-reads the
+    /// same range, so the upload body can be re-derived from the source on a retry.
     pub async fn read(&self, multi_part_options: Option<MultiPartOptions>) -> Result<CopyContent> {
         let mut file = fs::File::open(self.get_source()?).await?;
 
         // Read only the specified range if multipart is being used.
         let file: Box<dyn AsyncRead + Send + Sync + Unpin> =
-            if let Some(multipart) = multi_part_options {
+            if let Some(multipart) = &multi_part_options {
                 file.seek(SeekFrom::Start(multipart.start)).await?;
 
                 let size = multipart
@@ -88,7 +91,21 @@ impl File {
                 Box::new(file)
             };
 
-        Ok(CopyContent::new(file))
+        let self_clone = self.clone();
+        CopyContent::builder(file)
+            .with_reopen(move || {
+                self_clone.reopen_read(multi_part_options.clone())
+            })
+            .build()
+    }
+
+    /// Re-read the source range.
+    fn reopen_read(
+        &self,
+        multi_part_options: Option<MultiPartOptions>,
+    ) -> Pin<Box<dyn Future<Output = Result<CopyContent>> + Send>> {
+        let self_clone = self.clone();
+        Box::pin(async move { self_clone.read(multi_part_options).await })
     }
 
     /// Write the data to the destination.

--- a/copyrite/src/io/copy/file.rs
+++ b/copyrite/src/io/copy/file.rs
@@ -93,9 +93,7 @@ impl File {
 
         let self_clone = self.clone();
         CopyContent::builder(file)
-            .with_reopen(move || {
-                self_clone.reopen_read(multi_part_options.clone())
-            })
+            .with_reopen(move || self_clone.reopen_read(multi_part_options.clone()))
             .build()
     }
 
@@ -222,5 +220,92 @@ impl ObjectCopy for File {
         let source = self.get_source()?;
 
         Self::initialize_state(source).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tempfile::tempdir;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    const BODY: &[u8] = b"the quick brown fox jumps over the lazy dog";
+
+    async fn read_all(content: CopyContent) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut data = content.data;
+        data.read_to_end(&mut buf).await.unwrap();
+        buf
+    }
+
+    async fn write_source(dir: &std::path::Path) -> String {
+        let path = dir.join("source");
+        let mut file = fs::File::create(&path).await.unwrap();
+        file.write_all(BODY).await.unwrap();
+        file.flush().await.unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    #[tokio::test]
+    async fn reopen_reproduces_source() {
+        let tmp = tempdir().unwrap();
+        let source = write_source(tmp.path()).await;
+        let file = File::new(Some(source), None);
+
+        let content = file.download(None).await.unwrap();
+        assert_eq!(read_all(content).await, BODY);
+
+        let content = file.download(None).await.unwrap();
+        let reopened = (content.reopen)().await.unwrap();
+        assert_eq!(read_all(reopened).await, BODY);
+    }
+
+    #[tokio::test]
+    async fn reopen_reproduces_parts() {
+        let tmp = tempdir().unwrap();
+        let source = write_source(tmp.path()).await;
+        let file = File::new(Some(source), None);
+
+        let options = MultiPartOptions {
+            part_number: Some(1),
+            start: 4,
+            end: 19,
+            ..Default::default()
+        };
+        let expected = &BODY[4..19];
+
+        let content = file.download(Some(options.clone())).await.unwrap();
+        assert_eq!(read_all(content).await, expected);
+
+        // Reopen must re-read the identical range.
+        let content = file.download(Some(options)).await.unwrap();
+        let reopened = (content.reopen)().await.unwrap();
+        assert_eq!(read_all(reopened).await, expected);
+    }
+
+    #[tokio::test]
+    async fn download_upload() {
+        let tmp = tempdir().unwrap();
+        let source = write_source(tmp.path()).await;
+        let destination = tmp.path().join("destination");
+
+        let source_file = File::new(Some(source), None);
+        let destination_file = File::new(None, Some(destination.to_string_lossy().to_string()));
+        let state = CopyState::new(BODY.len() as u64, None, None);
+
+        let content = source_file.download(None).await.unwrap();
+        destination_file
+            .upload(content, None, &state)
+            .await
+            .unwrap();
+
+        let mut written = Vec::new();
+        fs::File::open(&destination)
+            .await
+            .unwrap()
+            .read_to_end(&mut written)
+            .await
+            .unwrap();
+        assert_eq!(written, BODY);
     }
 }

--- a/copyrite/src/io/copy/mod.rs
+++ b/copyrite/src/io/copy/mod.rs
@@ -18,40 +18,59 @@ pub mod aws;
 pub mod file;
 
 /// A function that re-opens the copy content stream from its source. This is lazily loaded
-/// to reread the source instead of holding bytes in memory unnecessarily when re-trying
-/// best-effort tagging mode.
-pub type Reopen = Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<CopyContent>> + Send>> + Send>;
+/// to reread the source instead of holding bytes in memory unnecessarily when re-trying.
+/// The reason this exists instead of using the default SDK mechanism is because we want to
+/// re-try explicitly when doing best-effort tagging mode.
+pub type Reopen =
+    Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<CopyContent>> + Send>> + Send + Sync>;
 
-/// Content to download/upload with optional tags.
+/// Content to download/upload, with a re-try function. Constructed using [`CopyContent::builder`].
 pub struct CopyContent {
     data: Box<dyn AsyncRead + Sync + Send + Unpin>,
-    reopen: Option<Reopen>,
+    reopen: Reopen,
 }
 
-impl Default for CopyContent {
-    fn default() -> Self {
+impl CopyContent {
+    /// Building a copy content from a data stream.
+    pub fn builder(data: Box<dyn AsyncRead + Sync + Send + Unpin>) -> CopyContentBuilder {
+        CopyContentBuilder { data, reopen: None }
+    }
+
+    /// Create an empty copy content placeholder.
+    pub fn empty() -> Self {
         Self {
             data: Box::new(empty()),
-            reopen: None,
+            reopen: Box::new(|| Box::pin(async { Ok(CopyContent::empty()) })),
         }
     }
 }
 
-impl CopyContent {
-    /// Create a new copy content struct.
-    pub fn new(data: Box<dyn AsyncRead + Sync + Send + Unpin>) -> Self {
-        Self { data, reopen: None }
-    }
+/// Builder for [`CopyContent`].
+pub struct CopyContentBuilder {
+    data: Box<dyn AsyncRead + Sync + Send + Unpin>,
+    reopen: Option<Reopen>,
+}
 
-    /// Attach a function that re-opens this stream from the source, so that an upload
-    /// can be retried.
+impl CopyContentBuilder {
+    /// Attach a function that re-opens this stream from the source, so that an upload can be
+    /// retried by re-reading the source rather than buffering it.
     pub fn with_reopen<F, Fut>(mut self, reopen: F) -> Self
     where
-        F: Fn() -> Fut + Send + 'static,
+        F: Fn() -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<CopyContent>> + Send + 'static,
     {
         self.reopen = Some(Box::new(move || Box::pin(reopen())));
         self
+    }
+
+    /// Build the copy content, failing if no reope was provided.
+    pub fn build(self) -> Result<CopyContent> {
+        Ok(CopyContent {
+            data: self.data,
+            reopen: self
+                .reopen
+                .ok_or_else(|| CopyError("copy content requires a reopen function".to_string()))?,
+        })
     }
 }
 

--- a/copyrite/src/io/copy/mod.rs
+++ b/copyrite/src/io/copy/mod.rs
@@ -10,20 +10,29 @@ use crate::io::copy::file::FileBuilder;
 use crate::io::{Provider, S3Client};
 use dyn_clone::DynClone;
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use tokio::io::{AsyncRead, empty};
 
 pub mod aws;
 pub mod file;
 
+/// A function that re-opens the copy content stream from its source. This is lazily loaded
+/// to reread the source instead of holding bytes in memory unnecessarily when re-trying
+/// best-effort tagging mode.
+pub type Reopen = Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<CopyContent>> + Send>> + Send>;
+
 /// Content to download/upload with optional tags.
 pub struct CopyContent {
     data: Box<dyn AsyncRead + Sync + Send + Unpin>,
+    reopen: Option<Reopen>,
 }
 
 impl Default for CopyContent {
     fn default() -> Self {
         Self {
             data: Box::new(empty()),
+            reopen: None,
         }
     }
 }
@@ -31,7 +40,18 @@ impl Default for CopyContent {
 impl CopyContent {
     /// Create a new copy content struct.
     pub fn new(data: Box<dyn AsyncRead + Sync + Send + Unpin>) -> Self {
-        Self { data }
+        Self { data, reopen: None }
+    }
+
+    /// Attach a function that re-opens this stream from the source, so that an upload
+    /// can be retried.
+    pub fn with_reopen<F, Fut>(mut self, reopen: F) -> Self
+    where
+        F: Fn() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<CopyContent>> + Send + 'static,
+    {
+        self.reopen = Some(Box::new(move || Box::pin(reopen())));
+        self
     }
 }
 

--- a/copyrite/src/task/copy.rs
+++ b/copyrite/src/task/copy.rs
@@ -418,7 +418,6 @@ impl CopyTaskBuilder {
             source_copy,
             destination_copy,
             copy_mode,
-            tag_mode: this.tag_mode,
             object_size: settings.object_size,
             concurrency,
             state,
@@ -470,7 +469,6 @@ pub struct CopyTask {
     source_copy: Box<dyn ObjectCopy + Send + Sync>,
     destination_copy: Box<dyn ObjectCopy + Send + Sync>,
     copy_mode: CopyMode,
-    tag_mode: MetadataCopy,
     object_size: u64,
     concurrency: usize,
     state: CopyState,
@@ -622,15 +620,9 @@ impl CopyTask {
                 .await?
             }
             (CopyMode::DownloadUpload, None) => {
-                let mut data = self.source_copy.download(None).await?;
-                // Only best effort tagging retries the upload.
-                if self.tag_mode.is_best_effort() {
-                    let source = self.source_copy.clone();
-                    data = data.with_reopen(move || {
-                        let source = source.clone();
-                        async move { source.download(None).await }
-                    });
-                }
+                // `download` attaches a reopen factory, so the upload body is retryable: the SDK
+                // can retry transient failures without buffering the object.
+                let data = self.source_copy.download(None).await?;
                 let upload = self
                     .destination_copy
                     .upload(data, None, &self.state)
@@ -646,7 +638,7 @@ impl CopyTask {
 
                 self.run_multipart(
                     part_size,
-                    |option, _| async move { source.download(Some(option.clone())).await },
+                    |option, _| async move { source.download(Some(option)).await },
                     |data, options, state| async move {
                         destination.upload(data, Some(options), &state).await
                     },

--- a/copyrite/src/task/copy.rs
+++ b/copyrite/src/task/copy.rs
@@ -418,6 +418,7 @@ impl CopyTaskBuilder {
             source_copy,
             destination_copy,
             copy_mode,
+            tag_mode: this.tag_mode,
             object_size: settings.object_size,
             concurrency,
             state,
@@ -469,6 +470,7 @@ pub struct CopyTask {
     source_copy: Box<dyn ObjectCopy + Send + Sync>,
     destination_copy: Box<dyn ObjectCopy + Send + Sync>,
     copy_mode: CopyMode,
+    tag_mode: MetadataCopy,
     object_size: u64,
     concurrency: usize,
     state: CopyState,
@@ -620,7 +622,15 @@ impl CopyTask {
                 .await?
             }
             (CopyMode::DownloadUpload, None) => {
-                let data = self.source_copy.download(None).await?;
+                let mut data = self.source_copy.download(None).await?;
+                // Only best effort tagging retries the upload.
+                if self.tag_mode.is_best_effort() {
+                    let source = self.source_copy.clone();
+                    data = data.with_reopen(move || {
+                        let source = source.clone();
+                        async move { source.download(None).await }
+                    });
+                }
                 let upload = self
                     .destination_copy
                     .upload(data, None, &self.state)


### PR DESCRIPTION
Closes #78 

So I've found some issues with copyrite holding on to too much memory. This happens in the steps-s3-copy when using `download-upload` (which always occurs when copying to Ceph) that makes the 512MB fargate task run out of memory.

Before this PR, copyrite would download the full object into memory if using single-part copies (or individual parts if using multipart).

### Changes
* Streams data lazily in a download-upload copy using `ReaderStream` and `SdkBody`.
    * This is controlled by the `ReaderStream` and the concurrency level, which chunks data into 4KiB by default, but I've upped that to 64KiB as it's fairly low. 
* The complication with this is that the best-effort tagging mode which retries on an `AccessDenied` is not the default behaviour in the AWS SDK.
    * So, this adds a retry mechanism that mimics the SDK's retry on transient errors + supports the best effort tagging, using a channel sender and receiver.
* Adds test cases for aws and file based copies