### PR TITLE
chore: add release for 0.5.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,7 +49,7 @@ jobs:
           provenance: false
           platforms: "linux/amd64,linux/arm64"
           build-args: |
-            GITHUB_REPO_RELEASES_URL=https://github.com/umccr/cloud-checksum/releases/download
+            GITHUB_REPO_RELEASES_URL=https://github.com/umccr/copyrite/releases/download
             PACKAGE_VERSION=v${{ steps.tag.outputs.tag }}
           push: true
           tags: |

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -38,7 +38,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04-arm
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-apple-darwin
@@ -68,19 +68,23 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04-arm
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.get-release.outputs.tag }}
+      - name: Get package version from release tag
+        run: |
+          version="${{ needs.get-release.outputs.tag }}"
+          echo "PKG_VERSION=${version#v}" >> "$GITHUB_ENV"
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y rpm debhelper build-essential
+        run: sudo apt-get update && sudo apt-get install -y rpm debhelper build-essential devscripts
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Build RPM package
-        run: rpmbuild --define "_topdir $(pwd)/rpmbuild" --build-in-place --nodeps -bb pkg/rpm/copyrite.spec
+        run: rpmbuild --define "_topdir $(pwd)/rpmbuild" --define "version ${PKG_VERSION}" --build-in-place --nodeps -bb pkg/rpm/copyrite.spec
       - name: Release RPM assets
         uses: softprops/action-gh-release@v2
         with:
@@ -91,8 +95,13 @@ jobs:
       - name: Build Debian package
         env:
           DEB_BUILD_OPTIONS: noautodbgsym
+          DEBEMAIL: mmalenic1@gmail.com
+          DEBFULLNAME: Marko Malenic
         run: |
           cp -r pkg/debian .
+          if [ "$(dpkg-parsechangelog -S Version)" != "${PKG_VERSION}-1" ]; then
+            dch --newversion "${PKG_VERSION}-1" --distribution unstable "Release ${PKG_VERSION}"
+          fi
           dpkg-buildpackage --build=binary --no-sign
       - name: Release Debian assets
         uses: softprops/action-gh-release@v2

--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -1,3 +1,9 @@
+copyrite (0.5.1-1) unstable; urgency=low
+
+  * feat: improve error print output by @mmalenic in https://github.com/umccr/copyrite/pull/87
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Fri, 03 Jul 2026 00:00:00 +0000
+
 copyrite (0.5.0-1) unstable; urgency=low
 
   * fix: in-memory bytes by @mmalenic in https://github.com/umccr/copyrite/pull/79

--- a/pkg/rpm/copyrite.spec
+++ b/pkg/rpm/copyrite.spec
@@ -1,10 +1,12 @@
+%{!?version: %global version 0.5.1}
+
 Name:           copyrite
-Version:        0.4.0
+Version:        %{version}
 Release:        1%{?dist}
 Summary:        CLI tool for efficient checksum and copy operations across object stores
 
 License:        MIT
-URL:            https://github.com/mmalenic/copyrite
+URL:            https://github.com/umccr/copyrite
 
 %global debug_package %{nil}
 
@@ -21,6 +23,9 @@ install -D target/release/%{name} %{buildroot}%{_bindir}/%{name}
 %{_bindir}/%{name}
 
 %changelog
+* Fri Jul 03 2026 Marko Malenic <mmalenic1@gmail.com> - 0.5.1-1
+- feat: improve error print output by @mmalenic in https://github.com/umccr/copyrite/pull/87
+
 * Thu Jun 04 2026 Marko Malenic <mmalenic1@gmail.com> - 0.5.0-1
 - fix: in-memory bytes by @mmalenic in https://github.com/umccr/copyrite/pull/79
 - fix: max part size copy by @mmalenic in https://github.com/umccr/copyrite/pull/82


### PR DESCRIPTION
Related to #87 

### Changes
* Update changelogs for 0.5.1 and fix ubuntu image to support glibc 2.34 for AWS image compatibility.