### PR TITLE
fix: RequestChecksumCalculation from new AWS SDK switched off for S3 compatibility

### DIFF
--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -1010,7 +1010,7 @@ pub struct Compatibility {
     /// Enable all compatibility options.
     ///
     /// This is a convenience flag that enables `--force-path-style`,
-    /// `--no-get-object-attributes`, and `--no-checksum-mode`.
+    /// `--no-get-object-attributes`, `--no-checksum-mode`, and `--no-request-checksum`.
     ///
     /// For the copy command, each compatibility option can also be prefixed with
     /// `source-` or `destination-` to enable additional compatibility per-side (e.g.
@@ -1061,6 +1061,19 @@ pub struct Compatibility {
         hide_short_help = true
     )]
     pub no_checksum_mode: bool,
+    /// Disable automatic request checksum calculation by the AWS SDK.
+    ///
+    /// By default, the AWS SDK automatically computes and sends a CRC32 checksum on upload
+    /// requests (`PutObject`, `UploadPart`). Some S3-compatible endpoints such as Ceph do not
+    /// support this and will return `XAmzContentSHA256Mismatch` errors. This option sets
+    /// `request_checksum_calculation` to `WHEN_REQUIRED`, suppressing automatic checksums.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_NO_REQUEST_CHECKSUM",
+        hide_short_help = true
+    )]
+    pub no_request_checksum: bool,
     /// Controls overriding the AWS SDK's stalled stream protection.
     ///
     /// SSP is useful to prevent dead TCP connections from hanging if the SDK detects that no bytes are
@@ -1106,6 +1119,13 @@ pub struct Compatibility {
     #[arg(
         global = true,
         long,
+        env = "COPYRITE_SOURCE_NO_REQUEST_CHECKSUM",
+        hide = true
+    )]
+    pub source_no_request_checksum: bool,
+    #[arg(
+        global = true,
+        long,
         env = "COPYRITE_SOURCE_STALLED_STREAM_PROTECTION",
         hide = true
     )]
@@ -1141,6 +1161,13 @@ pub struct Compatibility {
     #[arg(
         global = true,
         long,
+        env = "COPYRITE_DESTINATION_NO_REQUEST_CHECKSUM",
+        hide = true
+    )]
+    pub destination_no_request_checksum: bool,
+    #[arg(
+        global = true,
+        long,
         env = "COPYRITE_DESTINATION_STALLED_STREAM_PROTECTION",
         hide = true
     )]
@@ -1161,6 +1188,11 @@ impl Compatibility {
     /// Whether to disable checksum mode.
     pub fn no_checksum_mode(&self) -> bool {
         self.s3_compatible || self.no_checksum_mode
+    }
+
+    /// Whether to disable automatic request checksum calculation.
+    pub fn no_request_checksum(&self) -> bool {
+        self.s3_compatible || self.no_request_checksum
     }
 
     /// Whether to force path-style addressing for the source.
@@ -1194,11 +1226,23 @@ impl Compatibility {
         self.source_s3_compatible || self.source_no_checksum_mode || self.no_checksum_mode()
     }
 
+    /// Whether to disable automatic request checksum calculation for the source.
+    pub fn source_no_request_checksum(&self) -> bool {
+        self.source_s3_compatible || self.source_no_request_checksum || self.no_request_checksum()
+    }
+
     /// Whether to disable checksum mode for the destination.
     pub fn destination_no_checksum_mode(&self) -> bool {
         self.destination_s3_compatible
             || self.destination_no_checksum_mode
             || self.no_checksum_mode()
+    }
+
+    /// Whether to disable automatic request checksum calculation for the destination.
+    pub fn destination_no_request_checksum(&self) -> bool {
+        self.destination_s3_compatible
+            || self.destination_no_request_checksum
+            || self.no_request_checksum()
     }
 
     /// The SSP configuration for the source.
@@ -1219,11 +1263,13 @@ impl Compatibility {
             || self.source_force_path_style
             || self.source_no_get_object_attributes
             || self.source_no_checksum_mode
+            || self.source_no_request_checksum
             || self.source_stalled_stream_protection.is_some()
             || self.destination_s3_compatible
             || self.destination_force_path_style
             || self.destination_no_get_object_attributes
             || self.destination_no_checksum_mode
+            || self.destination_no_request_checksum
             || self.destination_stalled_stream_protection.is_some()
     }
 }

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -227,16 +227,15 @@ impl S3Client {
                 .credentials_provider(merged)
                 .force_path_style(force_path_style);
             if no_request_checksum {
-                builder = builder
-                    .request_checksum_calculation(RequestChecksumCalculation::WhenRequired);
+                builder =
+                    builder.request_checksum_calculation(RequestChecksumCalculation::WhenRequired);
             }
             builder.build()
         } else {
-            let mut builder = config::Builder::from(&sdk_config)
-                .force_path_style(force_path_style);
+            let mut builder = config::Builder::from(&sdk_config).force_path_style(force_path_style);
             if no_request_checksum {
-                builder = builder
-                    .request_checksum_calculation(RequestChecksumCalculation::WhenRequired);
+                builder =
+                    builder.request_checksum_calculation(RequestChecksumCalculation::WhenRequired);
             }
             builder.build()
         };

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -170,6 +170,7 @@ impl S3Client {
 
     /// Create an S3 client from the credentials provider, profile, region and endpoint url.
     /// Any fields set in `overrides` take precedence over the resolved credential provider values.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_s3_client(
         provider: &CredentialProvider,
         profile: Option<&str>,

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, Result};
 use aws_config::Region;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_sdk_s3::client::customize::CustomizableOperation;
-use aws_sdk_s3::config::StalledStreamProtectionConfig;
+use aws_sdk_s3::config::{RequestChecksumCalculation, StalledStreamProtectionConfig};
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation;
 use aws_sdk_s3::{Client, config};
@@ -100,6 +100,7 @@ impl S3Client {
             credentials.effective_source_secret(),
             credentials.source_overrides(),
             compatibility.source_force_path_style(),
+            compatibility.source_no_request_checksum(),
         )
         .await?;
 
@@ -124,6 +125,7 @@ impl S3Client {
             credentials.effective_destination_secret(),
             credentials.destination_overrides(),
             compatibility.destination_force_path_style(),
+            compatibility.destination_no_request_checksum(),
         )
         .await?;
 
@@ -176,6 +178,7 @@ impl S3Client {
         secret: Option<&str>,
         overrides: CredentialOverrides,
         force_path_style: bool,
+        no_request_checksum: bool,
     ) -> Result<Client> {
         let mut loader = aws_config::defaults(BehaviorVersion::latest());
 
@@ -220,14 +223,22 @@ impl S3Client {
             };
 
             let merged = overrides.merge_with(base.as_ref())?;
-            config::Builder::from(&sdk_config)
+            let mut builder = config::Builder::from(&sdk_config)
                 .credentials_provider(merged)
-                .force_path_style(force_path_style)
-                .build()
+                .force_path_style(force_path_style);
+            if no_request_checksum {
+                builder = builder
+                    .request_checksum_calculation(RequestChecksumCalculation::WhenRequired);
+            }
+            builder.build()
         } else {
-            config::Builder::from(&sdk_config)
-                .force_path_style(force_path_style)
-                .build()
+            let mut builder = config::Builder::from(&sdk_config)
+                .force_path_style(force_path_style);
+            if no_request_checksum {
+                builder = builder
+                    .request_checksum_calculation(RequestChecksumCalculation::WhenRequired);
+            }
+            builder.build()
         };
 
         Ok(Client::from_conf(s3_config))
@@ -247,6 +258,7 @@ impl S3Client {
             None,
             None,
             no_overrides,
+            false,
             false,
         )
         .await

--- a/copyrite/tests/copy.rs
+++ b/copyrite/tests/copy.rs
@@ -103,6 +103,7 @@ async fn copy_test() -> Result<()> {
         config.secret.as_deref(),
         no_overrides,
         config.is_s3_compatible(),
+        config.is_s3_compatible(),
     )
     .await?;
 


### PR DESCRIPTION
Introduced an option that disables request checksums (which had been enabled automatically in the AWS SDK)