### PR TITLE
fix: pairing clients with their source/destination location properly

### DIFF
--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -11,6 +11,7 @@ use crate::io::sums::channel::ChannelReader;
 use crate::io::{CredentialOverrides, Provider};
 use crate::stats;
 use crate::stats::{CheckStats, ChecksumPair, CopyStats, GenerateStats};
+use crate::task::ClientInput;
 use crate::task::check::{CheckTask, CheckTaskBuilder, GroupBy};
 use crate::task::copy::CopyTaskBuilder;
 use crate::task::generate::{GenerateTaskBuilder, SumCtxPairs};
@@ -120,8 +121,13 @@ impl Command {
 
         match self.commands {
             Subcommands::Generate(generate_args) => {
+                let inputs = generate_args
+                    .input
+                    .iter()
+                    .map(|input| ClientInput::new(input.clone(), Some(client.clone())))
+                    .collect();
                 match generate_args
-                    .generate(self.optimization, vec![client], true)
+                    .generate(self.optimization, inputs, true)
                     .await
                 {
                     Ok(stats) => {
@@ -139,8 +145,13 @@ impl Command {
                 }
             }
             Subcommands::Check(check_args) => {
+                let inputs = check_args
+                    .input
+                    .iter()
+                    .map(|input| ClientInput::new(input.clone(), Some(client.clone())))
+                    .collect();
                 match check_args
-                    .check(self.optimization, write_sums_file, false, vec![client])
+                    .check(self.optimization, write_sums_file, false, inputs)
                     .await
                 {
                     Ok(output) => Self::print_stats(&output, pretty_json, ui)?,
@@ -280,7 +291,7 @@ impl Generate {
     pub async fn generate(
         self,
         optimization: Optimization,
-        clients: Vec<S3Client>,
+        inputs: Vec<ClientInput>,
         write_sums_file: bool,
     ) -> stats::Result<GenerateStats> {
         if self.input[0] == "-" {
@@ -291,7 +302,7 @@ impl Generate {
                 .with_verify(self.verify)
                 .with_context(self.checksum)
                 .with_reader(reader)
-                .set_client(clients.first().cloned())
+                .set_client(inputs.first().and_then(ClientInput::client))
                 .build()
                 .await?
                 .run()
@@ -312,8 +323,7 @@ impl Generate {
 
             if self.missing {
                 let now = Instant::now();
-                let (ctxs, group_by) =
-                    Check::comparable_check(self.input.clone(), clients.clone()).await?;
+                let (ctxs, group_by) = Check::comparable_check(inputs.clone()).await?;
                 let (objects, compared, updated, api_errors) = ctxs.into_inner();
                 check_stats = Some(
                     CheckStats::new(
@@ -329,19 +339,22 @@ impl Generate {
 
                 let ctxs = SumCtxPairs::from_comparable(objects)?;
                 if let Some(ctxs) = ctxs {
-                    for (ctx, client) in ctxs
-                        .into_inner()
-                        .into_iter()
-                        .zip(clients.clone().into_iter().cycle())
-                    {
+                    for ctx in ctxs.into_inner() {
                         let (input, ctx) = ctx.into_inner();
+                        // Select the client that belongs to this location by matching it against
+                        // the input list.
+                        let client = inputs
+                            .iter()
+                            .find(|client_input| client_input.location() == input.as_str())
+                            .and_then(ClientInput::client)
+                            .or_else(|| inputs.first().and_then(ClientInput::client));
                         let task = GenerateTaskBuilder::default()
                             .with_overwrite(self.force_overwrite)
                             .with_verify(self.verify)
                             .with_input_file_name(input.to_string())
                             .with_context(vec![ctx])
                             .with_capacity(optimization.channel_capacity)
-                            .with_client(client)
+                            .set_client(client)
                             .set_write(write_sums_file)
                             .build()
                             .await?
@@ -364,14 +377,15 @@ impl Generate {
                 }
             };
 
-            for (input, client) in self.input.into_iter().zip(clients.into_iter().cycle()) {
+            for client_input in inputs {
+                let (input, client) = client_input.into_inner();
                 let task = GenerateTaskBuilder::default()
                     .with_overwrite(self.force_overwrite)
                     .with_verify(self.verify)
                     .with_input_file_name(input.to_string())
                     .with_context(self.checksum.clone())
                     .with_capacity(optimization.channel_capacity)
-                    .with_client(client)
+                    .set_client(client)
                     .set_write(write_sums_file)
                     .build()
                     .await?
@@ -422,15 +436,11 @@ pub struct Check {
 
 impl Check {
     /// Perform a check for comparability on the input files.
-    pub async fn comparable_check(
-        input: Vec<String>,
-        clients: Vec<S3Client>,
-    ) -> Result<(CheckTask, GroupBy)> {
+    pub async fn comparable_check(inputs: Vec<ClientInput>) -> Result<(CheckTask, GroupBy)> {
         Ok((
             CheckTaskBuilder::default()
-                .with_input_files(input)
+                .with_inputs(inputs)
                 .with_group_by(GroupBy::Comparability)
-                .with_clients(clients)
                 .build()
                 .await?
                 .run()
@@ -454,19 +464,18 @@ impl Check {
         optimization: Optimization,
         write_sums_file: bool,
         verify: bool,
-        clients: Vec<S3Client>,
+        inputs: Vec<ClientInput>,
     ) -> stats::Result<CheckStats> {
         let now = Instant::now();
         let group_by = self.group_by;
 
         let mut builder = CheckTaskBuilder::default()
             .with_group_by(group_by)
-            .with_input_files(self.input.clone())
-            .with_update(self.update)
-            .with_clients(clients.clone());
+            .with_inputs(inputs.clone())
+            .with_update(self.update);
         let mut generate_stats = None;
         if self.missing {
-            let (ctxs, _) = Check::comparable_check(self.input.clone(), clients.clone()).await?;
+            let (ctxs, _) = Check::comparable_check(inputs.clone()).await?;
             let checksum = Check::generate_sums(ctxs);
 
             let mut stats = Generate {
@@ -476,7 +485,7 @@ impl Check {
                 force_overwrite: false,
                 verify,
             }
-            .generate(optimization, clients.clone(), write_sums_file)
+            .generate(optimization, inputs.clone(), write_sums_file)
             .await
             .map_err(|stats| CheckStats::from_generate_task(group_by, *stats))?;
             let sums = stats
@@ -691,20 +700,18 @@ impl Copy {
         verify: bool,
         write_sums_file: bool,
     ) -> stats::Result<CheckStats> {
-        let input = vec![self.source.to_string(), self.destination.to_string()];
+        let inputs = vec![
+            ClientInput::new(self.source.to_string(), Some(source_client)),
+            ClientInput::new(self.destination.to_string(), Some(destination_client)),
+        ];
 
         let result = Check {
-            input,
+            input: vec![self.source.to_string(), self.destination.to_string()],
             update: write_sums_file,
             group_by: GroupBy::Equality,
             missing: true,
         }
-        .check(
-            optimization,
-            write_sums_file,
-            verify,
-            vec![source_client, destination_client],
-        )
+        .check(optimization, write_sums_file, verify, inputs)
         .await?;
 
         Ok(result)

--- a/copyrite/src/task/check.rs
+++ b/copyrite/src/task/check.rs
@@ -7,6 +7,7 @@ use crate::error::{ApiError, Error, Result};
 use crate::io::S3Client;
 use crate::io::sums::{ObjectSums, ObjectSumsBuilder};
 use crate::stats::{CheckComparison, ChecksumPair};
+use crate::task::ClientInput;
 use clap::ValueEnum;
 use futures_util::future::join_all;
 use serde::{Deserialize, Serialize};
@@ -17,44 +18,33 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::{fmt, mem, result};
 
 /// Build a check task.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CheckTaskBuilder {
-    files: Vec<String>,
+    inputs: Vec<ClientInput>,
     sums_files: Vec<(String, SumsFile)>,
     group_by: GroupBy,
     update: bool,
-    clients: Vec<Option<S3Client>>,
-}
-
-impl Default for CheckTaskBuilder {
-    fn default() -> Self {
-        Self {
-            files: Default::default(),
-            sums_files: Default::default(),
-            group_by: Default::default(),
-            update: Default::default(),
-            // Ensure at least one element in the vector to repeat.
-            clients: vec![None],
-        }
-    }
 }
 
 impl CheckTaskBuilder {
-    /// Set the input files.
+    /// Set the inputs, each paired with the client used to access it.
+    pub fn with_inputs(mut self, inputs: Vec<ClientInput>) -> Self {
+        self.inputs = inputs;
+        self
+    }
+
+    /// Set the input files without any clients.
     pub fn with_input_files(mut self, files: Vec<String>) -> Self {
-        self.files = files;
+        self.inputs = files
+            .into_iter()
+            .map(|file| ClientInput::new(file, None))
+            .collect();
         self
     }
 
     /// Set the sums file directly without reading from input files.
     pub fn with_sums_files(mut self, files: Vec<(String, SumsFile)>) -> Self {
         self.sums_files = files;
-        self
-    }
-
-    /// Set the S3 client to use for each input file.
-    pub fn with_clients(mut self, clients: Vec<S3Client>) -> Self {
-        self.clients = clients.into_iter().map(Some).collect();
         self
     }
 
@@ -70,77 +60,80 @@ impl CheckTaskBuilder {
         self
     }
 
-    /// Set the S3 client to use.
-    pub fn with_client(mut self, client: S3Client) -> Self {
-        self.clients = vec![Some(client)];
-        self
-    }
-
     /// Build a check task.
-    pub async fn build(mut self) -> Result<CheckTask> {
+    pub async fn build(self) -> Result<CheckTask> {
         let group_by = self.group_by;
+        let update = self.update;
 
-        // Remove elements that are already set by in-memory sums files.
-        let in_memory = self
-            .sums_files
-            .iter()
-            .map(|(sums, _)| sums)
-            .collect::<Vec<_>>();
-        self.files.retain(|file| !in_memory.contains(&file));
+        // Locations already provided as in-memory sums files are not re-read from their source.
+        let mut sums_by_location: BTreeMap<String, SumsFile> =
+            self.sums_files.into_iter().collect();
+        let mut existing_states = Vec::new();
+        let mut to_read = Vec::new();
+        for input in self.inputs {
+            let location = input.location().to_string();
+            match sums_by_location.remove(&location) {
+                Some(sums) => existing_states.push((location, sums, input.client())),
+                None => to_read.push(input),
+            }
+        }
+        // Any in-memory sums without a matching input are still included, without a client.
+        for (location, sums) in sums_by_location {
+            existing_states.push((location, sums, None));
+        }
 
-        let task_client = self.clients.first().cloned().flatten();
-        let (objects, errors): (Vec<_>, Vec<_>) = join_all(
-            self.files
-                .into_iter()
-                .zip(self.clients.into_iter().cycle())
-                .map(|(file, client)| async move {
-                    let mut sums = ObjectSumsBuilder::default()
-                        .set_client(client)
-                        .build(file.to_string())
-                        .await?;
+        let (read_objects, errors): (Vec<_>, Vec<_>) =
+            join_all(to_read.into_iter().map(|input| async move {
+                let (location, client) = input.into_inner();
+                let mut sums = ObjectSumsBuilder::default()
+                    .set_client(client)
+                    .build(location)
+                    .await?;
 
-                    let file_size = sums.file_size().await?;
-                    let existing = sums
-                        .sums_file()
-                        .await?
-                        .unwrap_or_else(|| SumsFile::new(file_size, Default::default()));
+                let file_size = sums.file_size().await?;
+                let existing = sums
+                    .sums_file()
+                    .await?
+                    .unwrap_or_else(|| SumsFile::new(file_size, Default::default()));
 
-                    let errors = sums.api_errors();
-                    Ok((
-                        (
-                            SumsKey((existing, sums.location())),
-                            BTreeSet::from_iter(vec![State::ObjectSums(sums)]),
-                        ),
-                        errors,
-                    ))
-                }),
-        )
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>>>()?
-        .into_iter()
-        .unzip();
+                let errors = sums.api_errors();
+                Ok((
+                    (
+                        SumsKey((existing, sums.location())),
+                        BTreeSet::from_iter(vec![State::ObjectSums(sums)]),
+                    ),
+                    errors,
+                ))
+            }))
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .unzip();
 
-        let mut objects = BTreeMap::from_iter(objects);
+        let mut objects = BTreeMap::from_iter(read_objects);
         let errors = HashSet::from_iter(
             errors
                 .into_iter()
                 .flat_map(|err| err.into_iter().collect::<Vec<_>>()),
         );
 
-        for (location, sums) in self.sums_files {
+        for (location, sums, client) in existing_states {
             objects.insert(
                 SumsKey((sums.clone(), location.to_string())),
-                BTreeSet::from_iter(vec![State::ExistingSums((location, sums))]),
+                BTreeSet::from_iter(vec![State::ExistingSums {
+                    location,
+                    sums,
+                    client,
+                }]),
             );
         }
 
         Ok(CheckTask {
             objects: CheckObjects(objects),
             group_by,
-            update: self.update,
+            update,
             recoverable_errors: errors,
-            client: task_client,
             ..Default::default()
         })
     }
@@ -161,7 +154,11 @@ pub enum GroupBy {
 #[derive(Clone)]
 pub enum State {
     ObjectSums(Box<dyn ObjectSums + Send>),
-    ExistingSums((String, SumsFile)),
+    ExistingSums {
+        location: String,
+        sums: SumsFile,
+        client: Option<S3Client>,
+    },
 }
 
 impl State {
@@ -169,7 +166,7 @@ impl State {
     pub fn location(&self) -> String {
         match self {
             State::ObjectSums(object) => object.location(),
-            State::ExistingSums((location, _)) => location.to_string(),
+            State::ExistingSums { location, .. } => location.to_string(),
         }
     }
 
@@ -177,7 +174,7 @@ impl State {
     pub async fn sums_file(&mut self) -> Result<Option<SumsFile>> {
         match self {
             State::ObjectSums(object) => object.sums_file().await,
-            State::ExistingSums((_, sums)) => Ok(Some(sums.clone())),
+            State::ExistingSums { sums, .. } => Ok(Some(sums.clone())),
         }
     }
 
@@ -191,12 +188,14 @@ impl State {
 
     /// Write the sums file to the location. If no object sums are used then this creates a new
     /// object sums to write the file.
-    pub async fn write_sums_file(&self, sums: &SumsFile, client: Option<S3Client>) -> Result<()> {
+    pub async fn write_sums_file(&self, sums: &SumsFile) -> Result<()> {
         match self {
             State::ObjectSums(object) => object.write_sums_file(sums).await,
-            State::ExistingSums((location, _)) => {
+            State::ExistingSums {
+                location, client, ..
+            } => {
                 ObjectSumsBuilder::default()
-                    .set_client(client)
+                    .set_client(client.clone())
                     .build(location.to_string())
                     .await?
                     .write_sums_file(sums)
@@ -329,7 +328,6 @@ pub struct CheckTask {
     update: bool,
     compared_directly: Vec<CheckComparison>,
     updated: Vec<String>,
-    client: Option<S3Client>,
     recoverable_errors: HashSet<ApiError>,
 }
 
@@ -417,7 +415,6 @@ impl CheckTask {
 
     async fn do_check(&mut self) -> Result<()> {
         let update = self.update && matches!(self.group_by, GroupBy::Equality);
-        let client = self.client.clone();
         match self.group_by {
             GroupBy::Equality => self.merge_same().await,
             GroupBy::Comparability => self.merge_comparable().await,
@@ -432,7 +429,7 @@ impl CheckTask {
 
                     self.recoverable_errors.extend(location.api_errors());
                     if current.as_ref() != Some(file) {
-                        location.write_sums_file(file, client.clone()).await?;
+                        location.write_sums_file(file).await?;
                         updated_sums.push(location.location());
                     }
                 }
@@ -502,13 +499,94 @@ impl CheckTask {
 pub(crate) mod test {
     use super::*;
     use crate::checksum::file::Checksum;
+    use crate::checksum::standard::test::EXPECTED_MD5_SUM;
     use crate::error::Error;
     use crate::io::sums::file::FileBuilder;
     use crate::test::TEST_FILE_SIZE;
     use anyhow::Result;
+    use aws_sdk_s3::Client;
+    use aws_sdk_s3::operation::get_object::GetObjectError;
+    use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
+    use aws_sdk_s3::types::error::{NoSuchKey, NotFound};
+    use aws_smithy_mocks::{RuleMode, mock, mock_client};
     use std::collections::BTreeMap;
     use std::path::Path;
+    use std::sync::Arc;
     use tempfile::{TempDir, tempdir};
+
+    #[tokio::test]
+    async fn build_each_input_with_client() -> Result<()> {
+        let head = mock!(Client::head_object)
+            .match_requests(|req| req.bucket() == Some("bucket") && req.key() == Some("key"))
+            .then_output(|| {
+                HeadObjectOutput::builder()
+                    .e_tag(EXPECTED_MD5_SUM)
+                    .content_length(100)
+                    .build()
+            });
+        let get_sums = mock!(Client::get_object)
+            .match_requests(|req| req.bucket() == Some("bucket") && req.key() == Some("key.sums"))
+            .then_error(|| GetObjectError::NoSuchKey(NoSuchKey::builder().build()));
+        let destination_rules = vec![head, get_sums];
+        let destination_client = S3Client::new(
+            Arc::new(mock_client!(
+                aws_sdk_s3,
+                RuleMode::Sequential,
+                destination_rules.as_slice()
+            )),
+            true,
+            true,
+        );
+
+        let source_head = mock!(Client::head_object)
+            .match_requests(|req| req.bucket() == Some("bucket") && req.key() == Some("key"))
+            .then_error(|| HeadObjectError::NotFound(NotFound::builder().build()));
+        let source_rules = vec![source_head];
+        let source_client = S3Client::new(
+            Arc::new(mock_client!(
+                aws_sdk_s3,
+                RuleMode::Sequential,
+                source_rules.as_slice()
+            )),
+            true,
+            true,
+        );
+
+        let in_memory_location = "in-memory".to_string();
+        let s3_location = "s3://bucket/key".to_string();
+        let in_memory_sums = SumsFile::new(
+            Some(100),
+            BTreeMap::from_iter(vec![(
+                "md5".parse()?,
+                Checksum::new(EXPECTED_MD5_SUM.to_string()),
+            )]),
+        );
+
+        let task = CheckTaskBuilder::default()
+            .with_inputs(vec![
+                ClientInput::new(in_memory_location.clone(), Some(source_client)),
+                ClientInput::new(s3_location.clone(), Some(destination_client)),
+            ])
+            .with_sums_files(vec![(in_memory_location, in_memory_sums)])
+            .build()
+            .await?;
+
+        let entry = task
+            .state_objects()
+            .keys()
+            .find(|key| key.0.1 == s3_location)
+            .unwrap();
+        assert!(
+            entry
+                .0
+                .0
+                .checksums
+                .values()
+                .any(|checksum| checksum == &Checksum::new(EXPECTED_MD5_SUM.to_string()))
+        );
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_check() -> Result<()> {

--- a/copyrite/src/task/mod.rs
+++ b/copyrite/src/task/mod.rs
@@ -4,3 +4,34 @@
 pub mod check;
 pub mod copy;
 pub mod generate;
+
+use crate::io::S3Client;
+
+/// An input location paired with the S3 client used to access it.
+#[derive(Debug, Clone, Default)]
+pub struct ClientInput {
+    location: String,
+    client: Option<S3Client>,
+}
+
+impl ClientInput {
+    /// Create a new client input.
+    pub fn new(location: String, client: Option<S3Client>) -> Self {
+        Self { location, client }
+    }
+
+    /// The input location.
+    pub fn location(&self) -> &str {
+        &self.location
+    }
+
+    /// The client for this location, if any.
+    pub fn client(&self) -> Option<S3Client> {
+        self.client.clone()
+    }
+
+    /// Get the inner values.
+    pub fn into_inner(self) -> (String, Option<S3Client>) {
+        (self.location, self.client)
+    }
+}

--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -1,3 +1,15 @@
+copyrite (0.7.0-1) unstable; urgency=low
+
+  * fix: pairing clients with their source/destination location properly by @mmalenic in https://github.com/umccr/copyrite/pull/97
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Mon, 21 Jul 2026 00:00:00 +0000
+
+copyrite (0.6.0-1) unstable; urgency=low
+
+  * fix: option to disable request checksums by @andrewpatto in https://github.com/umccr/copyrite/pull/94
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Wed, 16 Jul 2026 00:00:00 +0000
+
 copyrite (0.5.1-1) unstable; urgency=low
 
   * feat: improve error print output by @mmalenic in https://github.com/umccr/copyrite/pull/87

--- a/pkg/rpm/copyrite.spec
+++ b/pkg/rpm/copyrite.spec
@@ -1,4 +1,4 @@
-%{!?version: %global version 0.5.1}
+%{!?version: %global version 0.7.0}
 
 Name:           copyrite
 Version:        %{version}
@@ -23,6 +23,12 @@ install -D target/release/%{name} %{buildroot}%{_bindir}/%{name}
 %{_bindir}/%{name}
 
 %changelog
+* Mon Jul 21 2026 Marko Malenic <mmalenic1@gmail.com> - 0.7.0-1
+- fix: pairing clients with their source/destination location properly by @mmalenic in https://github.com/umccr/copyrite/pull/97
+
+* Wed Jul 16 2026 Marko Malenic <mmalenic1@gmail.com> - 0.6.0-1
+- fix: option to disable request checksums by @andrewpatto in https://github.com/umccr/copyrite/pull/94
+
 * Fri Jul 03 2026 Marko Malenic <mmalenic1@gmail.com> - 0.5.1-1
 - feat: improve error print output by @mmalenic in https://github.com/umccr/copyrite/pull/87
 


### PR DESCRIPTION
Closes #95 

So the fix was a little bit more obscure than I thought it would be. It turns out there was a bug that incorrectly paired the input location with the client that holds credentials. Which means it would use the default client, which fails on Ceph. I.e. it would never properly try a head object with Ceph credentials, it would try them with default S3 credentials.

### Changes
* Address the client/credential pairing issue by creating a dedicated struct that hold client/location pairs.
    * Previously zip calls would mismatch these in some places in the check command, resulting in incorrect credentials being used for a given source or destination.
* Add unit test for this specific instance. 