### PR TITLE
feat: new checksums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -3576,6 +3577,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
 
 [[package]]
 name = "yansi"

--- a/copyrite/Cargo.toml
+++ b/copyrite/Cargo.toml
@@ -31,6 +31,7 @@ sha2 = "0.11"
 crc32fast = "1"
 crc32c = "0.6"
 crc64fast-nvme = "1"
+xxhash-rust = { version = "0.8", features = ["xxh64", "xxh3"] }
 
 # Value parsing
 serde = { version = "1", features = ["derive"] }

--- a/copyrite/src/checksum/mod.rs
+++ b/copyrite/src/checksum/mod.rs
@@ -139,6 +139,7 @@ impl From<Ctx> for ChecksumAlgorithm {
             StandardCtx::CRC64NVME(_, _) => ChecksumAlgorithm::Crc64Nvme,
             StandardCtx::CRC32C(_, _) => ChecksumAlgorithm::Crc32C,
             StandardCtx::CRC32(_, _) => ChecksumAlgorithm::Crc32,
+            StandardCtx::MD5(_) => ChecksumAlgorithm::Md5,
             StandardCtx::SHA1(_) => ChecksumAlgorithm::Sha1,
             StandardCtx::SHA256(_) => ChecksumAlgorithm::Sha256,
             StandardCtx::SHA512(_) => ChecksumAlgorithm::Sha512,

--- a/copyrite/src/checksum/mod.rs
+++ b/copyrite/src/checksum/mod.rs
@@ -141,6 +141,10 @@ impl From<Ctx> for ChecksumAlgorithm {
             StandardCtx::CRC32(_, _) => ChecksumAlgorithm::Crc32,
             StandardCtx::SHA1(_) => ChecksumAlgorithm::Sha1,
             StandardCtx::SHA256(_) => ChecksumAlgorithm::Sha256,
+            StandardCtx::SHA512(_) => ChecksumAlgorithm::Sha512,
+            StandardCtx::XXHash64(_) => ChecksumAlgorithm::Xxhash64,
+            StandardCtx::XXHash3(_) => ChecksumAlgorithm::Xxhash3,
+            StandardCtx::XXHash128(_) => ChecksumAlgorithm::Xxhash128,
             // By default, set some algorithm if the context doesn't line up.
             _ => ChecksumAlgorithm::Crc64Nvme,
         }

--- a/copyrite/src/checksum/standard.rs
+++ b/copyrite/src/checksum/standard.rs
@@ -14,6 +14,8 @@ use std::hash::{Hash, Hasher};
 use std::mem::discriminant;
 use std::str::FromStr;
 use std::sync::Arc;
+use xxhash_rust::xxh3::Xxh3Default;
+use xxhash_rust::xxh64::Xxh64;
 
 /// The checksum calculator. This also defines the ordering of which checksums are preferred
 /// for generating/copying data.
@@ -30,6 +32,14 @@ pub enum StandardCtx {
     SHA1(Option<sha1::Sha1>),
     /// Calculate the SHA256 checksum.
     SHA256(Option<sha2::Sha256>),
+    /// Calculate the SHA512 checksum.
+    SHA512(Option<sha2::Sha512>),
+    /// Calculate the XXHash64 checksum.
+    XXHash64(Option<Xxh64>),
+    /// Calculate the XXHash3 64-bit checksum.
+    XXHash3(Option<Xxh3Default>),
+    /// Calculate the XXHash128 checksum.
+    XXHash128(Option<Xxh3Default>),
     /// Calculate the QuickXor checksum.
     QuickXor,
 }
@@ -87,9 +97,13 @@ impl FromStr for StandardCtx {
             Checksum::MD5 => Self::md5(),
             Checksum::SHA1 => Self::sha1(),
             Checksum::SHA256 => Self::sha256(),
+            Checksum::SHA512 => Self::sha512(),
             Checksum::CRC32 => Self::crc32(),
             Checksum::CRC32C => Self::crc32c(),
             Checksum::CRC64NVME => Self::crc64nvme(),
+            Checksum::XXHash64 => Self::xxhash64(),
+            Checksum::XXHash3 => Self::xxhash3(),
+            Checksum::XXHash128 => Self::xxhash128(),
             _ => return Err(ParseError("unsupported checksum algorithm".to_string())),
         };
         Ok(ctx)
@@ -103,8 +117,12 @@ impl From<&StandardCtx> for Checksum {
             StandardCtx::MD5(_) => Self::MD5,
             StandardCtx::SHA1(_) => Self::SHA1,
             StandardCtx::SHA256(_) => Self::SHA256,
+            StandardCtx::SHA512(_) => Self::SHA512,
             StandardCtx::CRC32(_, _) => Self::CRC32,
             StandardCtx::CRC32C(_, _) => Self::CRC32C,
+            StandardCtx::XXHash64(_) => Self::XXHash64,
+            StandardCtx::XXHash3(_) => Self::XXHash3,
+            StandardCtx::XXHash128(_) => Self::XXHash128,
             StandardCtx::QuickXor => Self::QuickXor,
         }
     }
@@ -116,6 +134,7 @@ impl Display for StandardCtx {
             StandardCtx::MD5(_) => write!(f, "md5"),
             StandardCtx::SHA1(_) => write!(f, "sha1"),
             StandardCtx::SHA256(_) => write!(f, "sha256"),
+            StandardCtx::SHA512(_) => write!(f, "sha512"),
             // Noting big-endian is the default if left unspecified.
             StandardCtx::CRC32(_, endianness) => match endianness {
                 Endianness::LittleEndian => write!(f, "crc32-{}", endianness),
@@ -129,6 +148,9 @@ impl Display for StandardCtx {
                 Endianness::LittleEndian => write!(f, "crc64nvme-{}", endianness),
                 Endianness::BigEndian => write!(f, "crc64nvme"),
             },
+            StandardCtx::XXHash64(_) => write!(f, "xxhash64"),
+            StandardCtx::XXHash3(_) => write!(f, "xxhash3"),
+            StandardCtx::XXHash128(_) => write!(f, "xxhash128"),
             StandardCtx::QuickXor => todo!(),
         }
     }
@@ -150,6 +172,11 @@ impl StandardCtx {
         Self::SHA256(Some(sha2::Sha256::new()))
     }
 
+    /// Create the SHA512 variant.
+    pub fn sha512() -> Self {
+        Self::SHA512(Some(sha2::Sha512::new()))
+    }
+
     /// Create the CRC32 variant.
     pub fn crc32() -> Self {
         Self::CRC32(Some(crc32fast::Hasher::new()), Endianness::BigEndian)
@@ -163,6 +190,21 @@ impl StandardCtx {
     /// Create the CRC64NVME variant.
     pub fn crc64nvme() -> Self {
         Self::CRC64NVME(Some(crc64fast_nvme::Digest::new()), Endianness::BigEndian)
+    }
+
+    /// Create the XXHash64 variant.
+    pub fn xxhash64() -> Self {
+        Self::XXHash64(Some(Xxh64::new(0)))
+    }
+
+    /// Create the XXHash3 64-bit variant.
+    pub fn xxhash3() -> Self {
+        Self::XXHash3(Some(Xxh3Default::new()))
+    }
+
+    /// Create the XXHash128 variant.
+    pub fn xxhash128() -> Self {
+        Self::XXHash128(Some(Xxh3Default::new()))
     }
 
     /// Parse into a `ChecksumCtx` for values that use endianness. Uses an -le suffix for
@@ -205,9 +247,13 @@ impl StandardCtx {
             StandardCtx::MD5(Some(ctx)) => ctx.update(data),
             StandardCtx::SHA1(Some(ctx)) => ctx.update(data),
             StandardCtx::SHA256(Some(ctx)) => ctx.update(data),
+            StandardCtx::SHA512(Some(ctx)) => ctx.update(data),
             StandardCtx::CRC32(Some(ctx), _) => ctx.update(&data),
             StandardCtx::CRC32C(ctx, _) => *ctx = crc32c_append(*ctx, &data),
             StandardCtx::CRC64NVME(Some(ctx), _) => ctx.write(&data),
+            StandardCtx::XXHash64(Some(ctx)) => ctx.update(&data),
+            StandardCtx::XXHash3(Some(ctx)) => ctx.update(&data),
+            StandardCtx::XXHash128(Some(ctx)) => ctx.update(&data),
             StandardCtx::QuickXor => todo!(),
             _ => panic!("cannot call update with empty context"),
         };
@@ -222,6 +268,7 @@ impl StandardCtx {
             StandardCtx::MD5(ctx) => ctx.take().expect(msg).finalize().to_vec(),
             StandardCtx::SHA1(ctx) => ctx.take().expect(msg).finalize().to_vec(),
             StandardCtx::SHA256(ctx) => ctx.take().expect(msg).finalize().to_vec(),
+            StandardCtx::SHA512(ctx) => ctx.take().expect(msg).finalize().to_vec(),
             StandardCtx::CRC32(ctx, endianness) => match endianness {
                 Endianness::LittleEndian => {
                     ctx.take().expect(msg).finalize().to_le_bytes().to_vec()
@@ -236,6 +283,15 @@ impl StandardCtx {
                 Endianness::LittleEndian => ctx.take().expect(msg).finish().to_le_bytes().to_vec(),
                 Endianness::BigEndian => ctx.take().expect(msg).finish().to_be_bytes().to_vec(),
             },
+            StandardCtx::XXHash64(ctx) => {
+                ctx.take().expect(msg).digest().to_be_bytes().to_vec()
+            }
+            StandardCtx::XXHash3(ctx) => {
+                ctx.take().expect(msg).digest().to_be_bytes().to_vec()
+            }
+            StandardCtx::XXHash128(ctx) => {
+                ctx.take().expect(msg).digest128().to_be_bytes().to_vec()
+            }
             StandardCtx::QuickXor => todo!(),
         };
 
@@ -248,9 +304,13 @@ impl StandardCtx {
             StandardCtx::MD5(_) => Self::md5(),
             StandardCtx::SHA1(_) => Self::sha1(),
             StandardCtx::SHA256(_) => Self::sha256(),
+            StandardCtx::SHA512(_) => Self::sha512(),
             StandardCtx::CRC32(_, endianness) => Self::crc32().with_endianness(*endianness),
             StandardCtx::CRC32C(_, endianness) => Self::crc32c().with_endianness(*endianness),
             StandardCtx::CRC64NVME(_, endianness) => Self::crc64nvme().with_endianness(*endianness),
+            StandardCtx::XXHash64(_) => Self::xxhash64(),
+            StandardCtx::XXHash3(_) => Self::xxhash3(),
+            StandardCtx::XXHash128(_) => Self::xxhash128(),
             StandardCtx::QuickXor => todo!(),
         }
     }
@@ -279,7 +339,11 @@ impl StandardCtx {
             StandardCtx::MD5(_) => 4,
             StandardCtx::SHA1(_) => 5,
             StandardCtx::SHA256(_) => 6,
-            StandardCtx::QuickXor => 7,
+            StandardCtx::SHA512(_) => 7,
+            StandardCtx::XXHash64(_) => 8,
+            StandardCtx::XXHash3(_) => 9,
+            StandardCtx::XXHash128(_) => 10,
+            StandardCtx::QuickXor => 11,
         }
     }
 

--- a/copyrite/src/checksum/standard.rs
+++ b/copyrite/src/checksum/standard.rs
@@ -283,12 +283,8 @@ impl StandardCtx {
                 Endianness::LittleEndian => ctx.take().expect(msg).finish().to_le_bytes().to_vec(),
                 Endianness::BigEndian => ctx.take().expect(msg).finish().to_be_bytes().to_vec(),
             },
-            StandardCtx::XXHash64(ctx) => {
-                ctx.take().expect(msg).digest().to_be_bytes().to_vec()
-            }
-            StandardCtx::XXHash3(ctx) => {
-                ctx.take().expect(msg).digest().to_be_bytes().to_vec()
-            }
+            StandardCtx::XXHash64(ctx) => ctx.take().expect(msg).digest().to_be_bytes().to_vec(),
+            StandardCtx::XXHash3(ctx) => ctx.take().expect(msg).digest().to_be_bytes().to_vec(),
             StandardCtx::XXHash128(ctx) => {
                 ctx.take().expect(msg).digest128().to_be_bytes().to_vec()
             }
@@ -378,15 +374,14 @@ pub(crate) mod test {
     pub(crate) const EXPECTED_SHA1_SUM: &str = "3eafdb6ad3a27167e0db70fccc40d0614307dabf"; // pragma: allowlist secret
     pub(crate) const EXPECTED_SHA256_SUM: &str =
         "29ffbd53cbe43179ab2fa62dbd958c0ec30b340ab50ce7c785e8a7a4b4771e39"; // pragma: allowlist secret
-    pub(crate) const EXPECTED_SHA512_SUM: &str =
-        "601bda6e0b7f39f8ed92aa4d9125b34c0321b6eb36622dcf0c8ed96847693e55fdd8f083b56746629369752d5ec6566a61eca2d41796245784595b3a6cf52f1e"; // pragma: allowlist secret
+    pub(crate) const EXPECTED_SHA512_SUM: &str = "601bda6e0b7f39f8ed92aa4d9125b34c0321b6eb36622dcf0c8ed96847693e55fdd8f083b56746629369752d5ec6566a61eca2d41796245784595b3a6cf52f1e"; // pragma: allowlist secret
     pub(crate) const EXPECTED_CRC32_BE_SUM: &str = "3320f39e";
     pub(crate) const EXPECTED_CRC32_LE_SUM: &str = "9ef32033";
     pub(crate) const EXPECTED_CRC32C_BE_SUM: &str = "4920106a";
     pub(crate) const EXPECTED_CRC32C_LE_SUM: &str = "6a102049";
-    pub(crate) const EXPECTED_XXHASH64_SUM: &str = "fde75bc952b2835f";
-    pub(crate) const EXPECTED_XXHASH3_SUM: &str = "3e714f0e42a90f5f";
-    pub(crate) const EXPECTED_XXHASH128_SUM: &str = "01c124e0c0eaf1903e714f0e42a90f5f";
+    pub(crate) const EXPECTED_XXHASH64_SUM: &str = "fde75bc952b2835f"; // pragma: allowlist secret
+    pub(crate) const EXPECTED_XXHASH3_SUM: &str = "3e714f0e42a90f5f"; // pragma: allowlist secret
+    pub(crate) const EXPECTED_XXHASH128_SUM: &str = "01c124e0c0eaf1903e714f0e42a90f5f"; // pragma: allowlist secret
 
     #[tokio::test]
     async fn test_md5() -> Result<()> {
@@ -447,7 +442,7 @@ pub(crate) mod test {
     fn test_xxhash64_known() -> Result<()> {
         assert_eq!(
             hex::encode(StandardCtx::xxhash64().finalize()?),
-            "ef46db3751d8e999"
+            "ef46db3751d8e999" // pragma: allowlist secret
         );
         Ok(())
     }
@@ -456,7 +451,7 @@ pub(crate) mod test {
     fn test_xxhash3_known() -> Result<()> {
         assert_eq!(
             hex::encode(StandardCtx::xxhash3().finalize()?),
-            "2d06800538d394c2"
+            "2d06800538d394c2" // pragma: allowlist secret
         );
         Ok(())
     }
@@ -465,7 +460,7 @@ pub(crate) mod test {
     fn test_xxhash128_known() -> Result<()> {
         assert_eq!(
             hex::encode(StandardCtx::xxhash128().finalize()?),
-            "99aa06d3014798d86001c324468d497f"
+            "99aa06d3014798d86001c324468d497f" // pragma: allowlist secret
         );
         Ok(())
     }

--- a/copyrite/src/checksum/standard.rs
+++ b/copyrite/src/checksum/standard.rs
@@ -369,17 +369,24 @@ impl StandardCtx {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use super::StandardCtx;
     use crate::checksum::test::test_checksum;
     use anyhow::Result;
+    use std::str::FromStr;
 
     pub(crate) const EXPECTED_MD5_SUM: &str = "d93e71879054f205ede90d35c8081ca5"; // pragma: allowlist secret
     pub(crate) const EXPECTED_SHA1_SUM: &str = "3eafdb6ad3a27167e0db70fccc40d0614307dabf"; // pragma: allowlist secret
     pub(crate) const EXPECTED_SHA256_SUM: &str =
         "29ffbd53cbe43179ab2fa62dbd958c0ec30b340ab50ce7c785e8a7a4b4771e39"; // pragma: allowlist secret
+    pub(crate) const EXPECTED_SHA512_SUM: &str =
+        "601bda6e0b7f39f8ed92aa4d9125b34c0321b6eb36622dcf0c8ed96847693e55fdd8f083b56746629369752d5ec6566a61eca2d41796245784595b3a6cf52f1e"; // pragma: allowlist secret
     pub(crate) const EXPECTED_CRC32_BE_SUM: &str = "3320f39e";
     pub(crate) const EXPECTED_CRC32_LE_SUM: &str = "9ef32033";
     pub(crate) const EXPECTED_CRC32C_BE_SUM: &str = "4920106a";
     pub(crate) const EXPECTED_CRC32C_LE_SUM: &str = "6a102049";
+    pub(crate) const EXPECTED_XXHASH64_SUM: &str = "fde75bc952b2835f";
+    pub(crate) const EXPECTED_XXHASH3_SUM: &str = "3e714f0e42a90f5f";
+    pub(crate) const EXPECTED_XXHASH128_SUM: &str = "01c124e0c0eaf1903e714f0e42a90f5f";
 
     #[tokio::test]
     async fn test_md5() -> Result<()> {
@@ -414,5 +421,61 @@ pub(crate) mod test {
     #[tokio::test]
     async fn test_crc32c_le() -> Result<()> {
         test_checksum("crc32c-le", EXPECTED_CRC32C_LE_SUM).await
+    }
+
+    #[tokio::test]
+    async fn test_sha512() -> Result<()> {
+        test_checksum("sha512", EXPECTED_SHA512_SUM).await
+    }
+
+    #[tokio::test]
+    async fn test_xxhash64() -> Result<()> {
+        test_checksum("xxhash64", EXPECTED_XXHASH64_SUM).await
+    }
+
+    #[tokio::test]
+    async fn test_xxhash3() -> Result<()> {
+        test_checksum("xxhash3", EXPECTED_XXHASH3_SUM).await
+    }
+
+    #[tokio::test]
+    async fn test_xxhash128() -> Result<()> {
+        test_checksum("xxhash128", EXPECTED_XXHASH128_SUM).await
+    }
+
+    #[test]
+    fn test_xxhash64_known() -> Result<()> {
+        assert_eq!(
+            hex::encode(StandardCtx::xxhash64().finalize()?),
+            "ef46db3751d8e999"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_xxhash3_known() -> Result<()> {
+        assert_eq!(
+            hex::encode(StandardCtx::xxhash3().finalize()?),
+            "2d06800538d394c2"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_xxhash128_known() -> Result<()> {
+        assert_eq!(
+            hex::encode(StandardCtx::xxhash128().finalize()?),
+            "99aa06d3014798d86001c324468d497f"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_new_checksums_name_round_trip() -> Result<()> {
+        for name in ["sha512", "xxhash64", "xxhash3", "xxhash128"] {
+            let ctx = StandardCtx::from_str(name)?;
+            assert_eq!(ctx.to_string(), name);
+        }
+        Ok(())
     }
 }

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -919,10 +919,13 @@ pub enum Checksum {
     /// Calculate a CRC64NVME.
     CRC64NVME,
     /// Calculate the XXHash64 checksum.
+    #[value(name = "xxhash64")]
     XXHash64,
     /// Calculate the XXHash3 64-bit checksum.
+    #[value(name = "xxhash3")]
     XXHash3,
     /// Calculate the XXHash128 checksum.
+    #[value(name = "xxhash128")]
     XXHash128,
     /// Calculate the QuickXor checksum.
     QuickXor,

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -910,12 +910,20 @@ pub enum Checksum {
     SHA1,
     /// Calculate the SHA256 checksum.
     SHA256,
+    /// Calculate the SHA512 checksum.
+    SHA512,
     /// Calculate a CRC32.
     CRC32,
     /// Calculate a CRC32C.
     CRC32C,
     /// Calculate a CRC64NVME.
     CRC64NVME,
+    /// Calculate the XXHash64 checksum.
+    XXHash64,
+    /// Calculate the XXHash3 64-bit checksum.
+    XXHash3,
+    /// Calculate the XXHash128 checksum.
+    XXHash128,
     /// Calculate the QuickXor checksum.
     QuickXor,
 }

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -138,7 +138,11 @@ impl From<(CopyPartResult, u64, String)> for CopyResult {
                 crc32_c: part.checksum_crc32_c,
                 sha1: part.checksum_sha1,
                 sha256: part.checksum_sha256,
+                sha512: part.checksum_sha512,
                 crc64_nvme: part.checksum_crc64_nvme,
+                xxhash64: part.checksum_xxhash64,
+                xxhash3: part.checksum_xxhash3,
+                xxhash128: part.checksum_xxhash128,
                 e_tag: part.e_tag,
                 part_number,
             },
@@ -156,7 +160,11 @@ impl From<(UploadPartOutput, u64, String)> for CopyResult {
                 crc32_c: part.checksum_crc32_c,
                 sha1: part.checksum_sha1,
                 sha256: part.checksum_sha256,
+                sha512: part.checksum_sha512,
                 crc64_nvme: part.checksum_crc64_nvme,
+                xxhash64: part.checksum_xxhash64,
+                xxhash3: part.checksum_xxhash3,
+                xxhash128: part.checksum_xxhash128,
                 e_tag: part.e_tag,
                 part_number,
             },
@@ -175,7 +183,11 @@ impl TryFrom<Part> for CompletedPart {
             .set_checksum_crc32_c(part.crc32_c)
             .set_checksum_sha1(part.sha1)
             .set_checksum_sha256(part.sha256)
+            .set_checksum_sha512(part.sha512)
             .set_checksum_crc64_nvme(part.crc64_nvme)
+            .set_checksum_xxhash64(part.xxhash64)
+            .set_checksum_xxhash3(part.xxhash3)
+            .set_checksum_xxhash128(part.xxhash128)
             .set_e_tag(part.e_tag)
             .set_part_number(Some(i32::try_from(part.part_number)?))
             .build())

--- a/copyrite/src/io/copy/mod.rs
+++ b/copyrite/src/io/copy/mod.rs
@@ -102,7 +102,11 @@ pub struct Part {
     pub(crate) crc32_c: Option<String>,
     pub(crate) sha1: Option<String>,
     pub(crate) sha256: Option<String>,
+    pub(crate) sha512: Option<String>,
     pub(crate) crc64_nvme: Option<String>,
+    pub(crate) xxhash64: Option<String>,
+    pub(crate) xxhash3: Option<String>,
+    pub(crate) xxhash128: Option<String>,
     pub(crate) e_tag: Option<String>,
     pub(crate) part_number: u64,
 }

--- a/copyrite/src/io/sums/aws.rs
+++ b/copyrite/src/io/sums/aws.rs
@@ -214,9 +214,13 @@ impl S3 {
             // Every other checksum has part checksums available if uploaded using multipart uploads.
             StandardCtx::SHA1(_) => head.checksum_sha1(),
             StandardCtx::SHA256(_) => head.checksum_sha256(),
+            StandardCtx::SHA512(_) => head.checksum_sha512(),
             StandardCtx::CRC32(_, _) => head.checksum_crc32(),
             StandardCtx::CRC32C(_, _) => head.checksum_crc32_c(),
             StandardCtx::CRC64NVME(_, _) => head.checksum_crc64_nvme(),
+            StandardCtx::XXHash64(_) => head.checksum_xxhash64(),
+            StandardCtx::XXHash3(_) => head.checksum_xxhash3(),
+            StandardCtx::XXHash128(_) => head.checksum_xxhash128(),
             _ => None,
         };
 
@@ -229,9 +233,13 @@ impl S3 {
             // Every checksum other than `ETag` has part checksums available if uploaded using multipart uploads.
             StandardCtx::SHA1(_) => part.checksum_sha1(),
             StandardCtx::SHA256(_) => part.checksum_sha256(),
+            StandardCtx::SHA512(_) => part.checksum_sha512(),
             StandardCtx::CRC32(_, _) => part.checksum_crc32(),
             StandardCtx::CRC32C(_, _) => part.checksum_crc32_c(),
             StandardCtx::CRC64NVME(_, _) => part.checksum_crc64_nvme(),
+            StandardCtx::XXHash64(_) => part.checksum_xxhash64(),
+            StandardCtx::XXHash3(_) => part.checksum_xxhash3(),
+            StandardCtx::XXHash128(_) => part.checksum_xxhash128(),
             // There are no part checksums for `ETag`s.
             _ => None,
         };
@@ -398,7 +406,15 @@ impl S3 {
             .await?;
         self.add_checksum(&mut sums_file, StandardCtx::sha256())
             .await?;
+        self.add_checksum(&mut sums_file, StandardCtx::sha512())
+            .await?;
         self.add_checksum(&mut sums_file, StandardCtx::crc64nvme())
+            .await?;
+        self.add_checksum(&mut sums_file, StandardCtx::xxhash64())
+            .await?;
+        self.add_checksum(&mut sums_file, StandardCtx::xxhash3())
+            .await?;
+        self.add_checksum(&mut sums_file, StandardCtx::xxhash128())
             .await?;
 
         if sums_file.checksums.is_empty() {

--- a/copyrite/src/io/sums/aws.rs
+++ b/copyrite/src/io/sums/aws.rs
@@ -16,6 +16,7 @@ use aws_sdk_s3::operation::get_object_attributes::GetObjectAttributesOutput;
 use aws_sdk_s3::operation::head_object::HeadObjectOutput;
 use aws_sdk_s3::types::{
     ChecksumAlgorithm, ChecksumMode, ChecksumType, ObjectAttributes, ObjectPart,
+    ServerSideEncryption,
 };
 use aws_smithy_types::byte_stream::ByteStream;
 use base64::Engine;
@@ -23,6 +24,35 @@ use base64::prelude::BASE64_STANDARD;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use tokio::io::AsyncRead;
+
+/// A raw checksum value retrieved from S3 metadata, with its encoding so that it can be
+/// decoded correctly. Additional checksums are base64 encoded, whereas `ETag`s are hex encoded.
+#[derive(Debug, Clone)]
+pub enum RawSum {
+    /// A base64 encoded additional checksum.
+    Additional(String),
+    /// A hex encoded `ETag`.
+    ETag(String),
+}
+
+impl RawSum {
+    /// Create an additional checksum.
+    pub fn additional(sum: &str) -> Self {
+        Self::Additional(sum.to_string())
+    }
+
+    /// Create an etag-based checksum.
+    pub fn e_tag(sum: &str) -> Self {
+        Self::ETag(sum.to_string())
+    }
+
+    /// Get the raw string value.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Additional(sum) | Self::ETag(sum) => sum,
+        }
+    }
+}
 
 /// Build an S3 sums object.
 #[derive(Debug, Default)]
@@ -177,59 +207,68 @@ impl S3 {
         Ok(self.head_object.entry(part_number).or_insert(head_object))
     }
 
-    /// Is this an additional checksum, i.e. not an `ETag`.
-    fn is_additional_checksum(ctx: &StandardCtx) -> bool {
-        !matches!(ctx, StandardCtx::MD5(_))
-    }
+    /// Decode a raw checksum into bytes. Additional checksums are base64 encoded when returned
+    /// from the SDK, whereas the `ETag` is hex encoded.
+    fn decode_sum(sum: &RawSum) -> Result<Vec<u8>> {
+        let value = sum.as_str().trim_matches('"');
+        let value = value.split('-').next().unwrap_or(value);
 
-    /// Decode the base64 encoded checksum if it is an additional checksum. All additional
-    /// checksums (not including the `ETag`) are base64 encoded when returned from the SDK.
-    /// The `ETag` is hex encoded.
-    fn decode_sum(ctx: &StandardCtx, sum: String) -> Result<Vec<u8>> {
-        let sum = sum
-            .trim_matches('"')
-            .split("-")
-            .next()
-            .unwrap_or_else(|| &sum);
-
-        if Self::is_additional_checksum(ctx) {
-            let data = BASE64_STANDARD
-                .decode(sum.as_bytes())
-                .map_err(|_| ParseError(format!("failed to decode base64 checksum: {}", sum)))?;
-
-            Ok(data)
-        } else {
-            Ok(hex::decode(sum.as_bytes())
-                .map_err(|_| ParseError(format!("failed to decode hex `ETag`: {}", sum)))?)
+        match sum {
+            RawSum::Additional(_) => BASE64_STANDARD
+                .decode(value.as_bytes())
+                .map_err(|_| ParseError(format!("failed to decode base64 checksum: {}", value))),
+            RawSum::ETag(_) => hex::decode(value.as_bytes())
+                .map_err(|_| ParseError(format!("failed to decode hex `ETag`: {}", value))),
         }
     }
 
-    /// Get the AWS checksum value from `HeadObject`.
-    pub async fn aws_sums_from_ctx(&mut self, ctx: &StandardCtx) -> Result<Option<String>> {
+    /// Get the AWS checksum value from `HeadObject`. For MD5 this prefers the native
+    /// `x-amz-checksum-md5` additional checksum. It falls back to the `ETag` only when the
+    /// `ETag` is a usable MD5, i.e. the object is not encrypted with SSE-KMS, SSE-C or others.
+    pub async fn aws_sums_from_ctx(&mut self, ctx: &StandardCtx) -> Result<Option<RawSum>> {
         let head = self.head_object(None).await?;
 
         let sum = match ctx {
-            // There are no part checksums for e_tags.
-            StandardCtx::MD5(_) => head.e_tag(),
-            // Every other checksum has part checksums available if uploaded using multipart uploads.
-            StandardCtx::SHA1(_) => head.checksum_sha1(),
-            StandardCtx::SHA256(_) => head.checksum_sha256(),
-            StandardCtx::SHA512(_) => head.checksum_sha512(),
-            StandardCtx::CRC32(_, _) => head.checksum_crc32(),
-            StandardCtx::CRC32C(_, _) => head.checksum_crc32_c(),
-            StandardCtx::CRC64NVME(_, _) => head.checksum_crc64_nvme(),
-            StandardCtx::XXHash64(_) => head.checksum_xxhash64(),
-            StandardCtx::XXHash3(_) => head.checksum_xxhash3(),
-            StandardCtx::XXHash128(_) => head.checksum_xxhash128(),
+            StandardCtx::MD5(_) => {
+                if let Some(md5) = head.checksum_md5() {
+                    Some(RawSum::additional(md5))
+                } else if Self::etag_is_md5(head) {
+                    head.e_tag().map(|e_tag| RawSum::ETag(e_tag.to_string()))
+                } else {
+                    None
+                }
+            }
+            // Every other checksum is an additional checksum, with part checksums available if
+            // uploaded using multipart uploads.
+            StandardCtx::SHA1(_) => head.checksum_sha1().map(RawSum::additional),
+            StandardCtx::SHA256(_) => head.checksum_sha256().map(RawSum::additional),
+            StandardCtx::SHA512(_) => head.checksum_sha512().map(RawSum::additional),
+            StandardCtx::CRC32(_, _) => head.checksum_crc32().map(RawSum::additional),
+            StandardCtx::CRC32C(_, _) => head.checksum_crc32_c().map(RawSum::additional),
+            StandardCtx::CRC64NVME(_, _) => head.checksum_crc64_nvme().map(RawSum::additional),
+            StandardCtx::XXHash64(_) => head.checksum_xxhash64().map(RawSum::additional),
+            StandardCtx::XXHash3(_) => head.checksum_xxhash3().map(RawSum::additional),
+            StandardCtx::XXHash128(_) => head.checksum_xxhash128().map(RawSum::additional),
             _ => None,
         };
 
-        Ok(sum.map(|sum| sum.to_string()))
+        Ok(sum)
+    }
+
+    /// Whether the `ETag` can be treated as an MD5. This is only the case for unencrypted objects
+    /// and those encrypted with SSE-S3, which preserve the MD5 `ETag`.
+    fn etag_is_md5(head: &HeadObjectOutput) -> bool {
+        matches!(
+            head.server_side_encryption(),
+            None | Some(ServerSideEncryption::Aes256)
+        ) && head.sse_customer_algorithm().is_none()
     }
 
     /// Get the AWS checksum part from `ObjectPart`.
     pub fn aws_parts_from_ctx(ctx: &StandardCtx, part: &ObjectPart) -> Option<String> {
         let sum = match ctx {
+            // The native MD5 additional checksum carries part checksums, unlike the `ETag`.
+            StandardCtx::MD5(_) => part.checksum_md5(),
             // Every checksum other than `ETag` has part checksums available if uploaded using multipart uploads.
             StandardCtx::SHA1(_) => part.checksum_sha1(),
             StandardCtx::SHA256(_) => part.checksum_sha256(),
@@ -344,7 +383,7 @@ impl S3 {
             _ => None,
         };
 
-        let sum = Self::decode_sum(&ctx, sum)?;
+        let digest = Self::decode_sum(&sum)?;
 
         // Create the AWS context with the available information. This can be a composite checksum
         // with a part size, or a regular context otherwise.
@@ -367,7 +406,7 @@ impl S3 {
             _ => Ctx::Regular(ctx),
         };
 
-        let checksum = Checksum::new(ctx.digest_to_string(&sum));
+        let checksum = Checksum::new(ctx.digest_to_string(&digest));
         sums_file.add_checksum(ctx, checksum);
 
         Ok(())
@@ -543,6 +582,7 @@ pub(crate) mod test {
     const EXPECTED_SHA256_PART_5: &str = "laScT3WEixthSDryDZwNEA+U5URMQ1Q8EXOO48F4v78="; // pragma: allowlist secret
 
     const EXPECTED_SHA256_PART_3_4_CONCAT: &str = "pWWT3JcI0KGHFujswlkNCTl1JfsSRpbmHyMcYIbjBQA="; // pragma: allowlist secret
+    const EXPECTED_MD5_SUM_BASE64: &str = "2T5xh5BU8gXt6Q01yAgcpQ=="; // pragma: allowlist secret
 
     #[tokio::test]
     pub async fn test_multi_part_with_sha256_different_part_sizes() -> anyhow::Result<()> {
@@ -684,6 +724,96 @@ pub(crate) mod test {
         let mut s3 = S3Builder::default()
             .with_client(S3Client::new(
                 Arc::new(mock_single_part_etag_only()),
+                false,
+                false,
+            ))
+            .with_bucket("bucket".to_string())
+            .with_key("key".to_string())
+            .build()?;
+
+        let sums = s3.sums_from_metadata().await?.split();
+        let expected = generate_for(TEST_FILE_NAME, vec!["md5"], true, false)
+            .await?
+            .split();
+
+        assert_all_same(sums, expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn test_md5_prefers_native_over_etag() -> Result<()> {
+        let mut s3 = s3_with_head(|b| {
+            b.e_tag(format!("\"{}\"", EXPECTED_MD5_SUM))
+                .checksum_md5(EXPECTED_MD5_SUM_BASE64)
+        })?;
+
+        let sum = s3.aws_sums_from_ctx(&StandardCtx::md5()).await?;
+        assert!(matches!(sum, Some(RawSum::Additional(sum)) if sum == EXPECTED_MD5_SUM_BASE64));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn test_md5_falls_back_to_etag() -> Result<()> {
+        let mut s3 = s3_with_head(|b| b.e_tag(format!("\"{}\"", EXPECTED_MD5_SUM)))?;
+
+        let sum = s3.aws_sums_from_ctx(&StandardCtx::md5()).await?;
+        assert!(matches!(sum, Some(RawSum::ETag(_))));
+        assert_eq!(
+            S3::decode_sum(&sum.unwrap())?,
+            S3::decode_sum(&RawSum::additional(EXPECTED_MD5_SUM_BASE64))?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn test_md5_suppressed_sse_kms_native() -> Result<()> {
+        let mut s3 = s3_with_head(|b| {
+            b.e_tag(format!("\"{}\"", EXPECTED_MD5_SUM))
+                .server_side_encryption(ServerSideEncryption::AwsKms)
+        })?;
+
+        assert!(s3.aws_sums_from_ctx(&StandardCtx::md5()).await?.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn test_md5_native_used_with_sse_kms() -> Result<()> {
+        let mut s3 = s3_with_head(|b| {
+            b.e_tag(format!("\"{}\"", EXPECTED_MD5_SUM))
+                .checksum_md5(EXPECTED_MD5_SUM_BASE64)
+                .server_side_encryption(ServerSideEncryption::AwsKms)
+        })?;
+
+        let sum = s3.aws_sums_from_ctx(&StandardCtx::md5()).await?;
+        assert!(matches!(sum, Some(RawSum::Additional(sum)) if sum == EXPECTED_MD5_SUM_BASE64));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn test_md5_etag_used_for_sse_s3() -> Result<()> {
+        let mut s3 = s3_with_head(|b| {
+            b.e_tag(format!("\"{}\"", EXPECTED_MD5_SUM))
+                .server_side_encryption(ServerSideEncryption::Aes256)
+        })?;
+
+        assert!(matches!(
+            s3.aws_sums_from_ctx(&StandardCtx::md5()).await?,
+            Some(RawSum::ETag(_))
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn test_single_part_native_md5() -> anyhow::Result<()> {
+        let mut s3 = S3Builder::default()
+            .with_client(S3Client::new(
+                Arc::new(mock_single_part_native_md5()),
                 false,
                 false,
             ))
@@ -983,5 +1113,53 @@ pub(crate) mod test {
                         .build()
                 }),
         ]
+    }
+
+    fn s3_with_head(
+        build: impl FnOnce(HeadObjectOutputBuilder) -> HeadObjectOutputBuilder,
+    ) -> Result<S3> {
+        let head = build(HeadObjectOutputBuilder::default()).build();
+        let rule = mock!(Client::head_object)
+            .match_requests(|req| req.bucket() == Some("bucket") && req.key() == Some("key"))
+            .then_output(move || head.clone());
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&rule]);
+
+        S3Builder::default()
+            .with_client(S3Client::new(Arc::new(client), false, false))
+            .with_bucket("bucket".to_string())
+            .with_key("key".to_string())
+            .build()
+    }
+
+    fn mock_single_part_native_md5() -> Client {
+        let get_object_attributes = mock!(Client::get_object_attributes)
+            .match_requests(|req| req.bucket() == Some("bucket") && req.key() == Some("key"))
+            .then_output(|| {
+                GetObjectAttributesOutput::builder()
+                    .e_tag(EXPECTED_MD5_SUM)
+                    .checksum(
+                        types::Checksum::builder()
+                            .checksum_md5(EXPECTED_MD5_SUM_BASE64)
+                            .build(),
+                    )
+                    .object_size(TEST_FILE_SIZE as i64)
+                    .build()
+            });
+
+        let head_object = mock!(Client::head_object)
+            .match_requests(|req| req.bucket() == Some("bucket") && req.key() == Some("key"))
+            .then_output(|| {
+                HeadObjectOutputBuilder::default()
+                    .e_tag(format!("\"{}\"", EXPECTED_MD5_SUM))
+                    .checksum_md5(EXPECTED_MD5_SUM_BASE64)
+                    .content_length(TEST_FILE_SIZE as i64)
+                    .build()
+            });
+
+        mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[&head_object, &get_object_attributes]
+        )
     }
 }


### PR DESCRIPTION
Closes #92 

### Changes
* Adds xxhash variants, native md5 and sha512.
    * A bit of a complication/fix with md5, as md5 is also and alias for etags in certain contexts:
        * The code now prefers the native md5 additional checksum if that's available. If it's not, it falls back to etags. These have different encoding, i.e. additional checksums are base64, whereas ETags are hex encoded.
* This also fixes an issue that treated etags computed from SSE-KMS/SSE-C as valid md5s, which is not the case: https://docs.aws.amazon.com/AmazonS3/latest/API/API_Object.html
        "Objects created by the PUT Object, POST Object, or Copy operation, or through the AWS Management Console, and are encrypted by SSE-C or SSE-KMS, have ETags that are not an MD5 digest of their object data."