### PR TITLE
fix: add new checksums to tests and properly run md5 through parts

### DIFF
--- a/copyrite/benches/generate.rs
+++ b/copyrite/benches/generate.rs
@@ -14,9 +14,14 @@ async fn channel_reader(path: &Path) {
         .with_context(vec![
             "sha1".parse().unwrap(),
             "sha256".parse().unwrap(),
+            "sha512".parse().unwrap(),
             "md5".parse().unwrap(),
             "crc32".parse().unwrap(),
             "crc32c".parse().unwrap(),
+            "crc64nvme".parse().unwrap(),
+            "xxhash64".parse().unwrap(),
+            "xxhash3".parse().unwrap(),
+            "xxhash128".parse().unwrap(),
         ])
         .with_reader(reader)
         .build()

--- a/copyrite/src/checksum/standard.rs
+++ b/copyrite/src/checksum/standard.rs
@@ -379,6 +379,8 @@ pub(crate) mod test {
     pub(crate) const EXPECTED_CRC32_LE_SUM: &str = "9ef32033";
     pub(crate) const EXPECTED_CRC32C_BE_SUM: &str = "4920106a";
     pub(crate) const EXPECTED_CRC32C_LE_SUM: &str = "6a102049";
+    pub(crate) const EXPECTED_CRC64NVME_BE_SUM: &str = "8827608f74ffad7b"; // pragma: allowlist secret
+    pub(crate) const EXPECTED_CRC64NVME_LE_SUM: &str = "7badff748f602788"; // pragma: allowlist secret
     pub(crate) const EXPECTED_XXHASH64_SUM: &str = "fde75bc952b2835f"; // pragma: allowlist secret
     pub(crate) const EXPECTED_XXHASH3_SUM: &str = "3e714f0e42a90f5f"; // pragma: allowlist secret
     pub(crate) const EXPECTED_XXHASH128_SUM: &str = "01c124e0c0eaf1903e714f0e42a90f5f"; // pragma: allowlist secret
@@ -416,6 +418,16 @@ pub(crate) mod test {
     #[tokio::test]
     async fn test_crc32c_le() -> Result<()> {
         test_checksum("crc32c-le", EXPECTED_CRC32C_LE_SUM).await
+    }
+
+    #[tokio::test]
+    async fn test_crc64nvme_be() -> Result<()> {
+        test_checksum("crc64nvme", EXPECTED_CRC64NVME_BE_SUM).await
+    }
+
+    #[tokio::test]
+    async fn test_crc64nvme_le() -> Result<()> {
+        test_checksum("crc64nvme-le", EXPECTED_CRC64NVME_LE_SUM).await
     }
 
     #[tokio::test]

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -143,6 +143,7 @@ impl From<(CopyPartResult, u64, String)> for CopyResult {
                 xxhash64: part.checksum_xxhash64,
                 xxhash3: part.checksum_xxhash3,
                 xxhash128: part.checksum_xxhash128,
+                md5: part.checksum_md5,
                 e_tag: part.e_tag,
                 part_number,
             },
@@ -165,6 +166,7 @@ impl From<(UploadPartOutput, u64, String)> for CopyResult {
                 xxhash64: part.checksum_xxhash64,
                 xxhash3: part.checksum_xxhash3,
                 xxhash128: part.checksum_xxhash128,
+                md5: part.checksum_md5,
                 e_tag: part.e_tag,
                 part_number,
             },
@@ -188,6 +190,7 @@ impl TryFrom<Part> for CompletedPart {
             .set_checksum_xxhash64(part.xxhash64)
             .set_checksum_xxhash3(part.xxhash3)
             .set_checksum_xxhash128(part.xxhash128)
+            .set_checksum_md5(part.md5)
             .set_e_tag(part.e_tag)
             .set_part_number(Some(i32::try_from(part.part_number)?))
             .build())
@@ -1057,6 +1060,53 @@ mod test {
 
         assert!(result.is_ok());
         assert_eq!(upload_part.num_calls(), 3);
+    }
+
+    #[test]
+    fn per_part_checksums_round_trip() -> Result<()> {
+        let output = UploadPartOutput::builder()
+            .checksum_crc32("crc32")
+            .checksum_crc32_c("crc32c")
+            .checksum_sha1("sha1")
+            .checksum_sha256("sha256")
+            .checksum_sha512("sha512")
+            .checksum_crc64_nvme("crc64nvme")
+            .checksum_xxhash64("xxhash64")
+            .checksum_xxhash3("xxhash3")
+            .checksum_xxhash128("xxhash128")
+            .checksum_md5("md5")
+            .e_tag("etag")
+            .build();
+        let completed: CompletedPart = CopyResult::from((output, 1u64, "id".to_string()))
+            .part
+            .expect("missing part")
+            .try_into()?;
+
+        assert_eq!(completed.checksum_crc32(), Some("crc32"));
+        assert_eq!(completed.checksum_crc32_c(), Some("crc32c"));
+        assert_eq!(completed.checksum_sha1(), Some("sha1"));
+        assert_eq!(completed.checksum_sha256(), Some("sha256"));
+        assert_eq!(completed.checksum_sha512(), Some("sha512"));
+        assert_eq!(completed.checksum_crc64_nvme(), Some("crc64nvme"));
+        assert_eq!(completed.checksum_xxhash64(), Some("xxhash64"));
+        assert_eq!(completed.checksum_xxhash3(), Some("xxhash3"));
+        assert_eq!(completed.checksum_xxhash128(), Some("xxhash128"));
+        assert_eq!(completed.checksum_md5(), Some("md5"));
+        assert_eq!(completed.e_tag(), Some("etag"));
+
+        let copy_part = CopyPartResult::builder()
+            .checksum_md5("md5")
+            .checksum_sha512("sha512")
+            .checksum_xxhash128("xxhash128")
+            .build();
+        let part = CopyResult::from((copy_part, 1u64, "id".to_string()))
+            .part
+            .expect("missing part");
+        assert_eq!(part.md5.as_deref(), Some("md5"));
+        assert_eq!(part.sha512.as_deref(), Some("sha512"));
+        assert_eq!(part.xxhash128.as_deref(), Some("xxhash128"));
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/copyrite/src/io/copy/mod.rs
+++ b/copyrite/src/io/copy/mod.rs
@@ -107,6 +107,7 @@ pub struct Part {
     pub(crate) xxhash64: Option<String>,
     pub(crate) xxhash3: Option<String>,
     pub(crate) xxhash128: Option<String>,
+    pub(crate) md5: Option<String>,
     pub(crate) e_tag: Option<String>,
     pub(crate) part_number: u64,
 }

--- a/copyrite/src/task/generate.rs
+++ b/copyrite/src/task/generate.rs
@@ -445,8 +445,9 @@ pub(crate) mod test {
     use crate::checksum::aws_etag::test::expected_md5_1gib;
     use crate::checksum::standard::StandardCtx;
     use crate::checksum::standard::test::{
-        EXPECTED_CRC32_BE_SUM, EXPECTED_CRC32C_BE_SUM, EXPECTED_MD5_SUM, EXPECTED_SHA1_SUM,
-        EXPECTED_SHA256_SUM,
+        EXPECTED_CRC32_BE_SUM, EXPECTED_CRC32C_BE_SUM, EXPECTED_CRC64NVME_BE_SUM, EXPECTED_MD5_SUM,
+        EXPECTED_SHA1_SUM, EXPECTED_SHA256_SUM, EXPECTED_SHA512_SUM, EXPECTED_XXHASH3_SUM,
+        EXPECTED_XXHASH64_SUM, EXPECTED_XXHASH128_SUM,
     };
     use crate::io::sums::channel::test::channel_reader;
     use crate::io::sums::file::FileBuilder;
@@ -493,7 +494,19 @@ pub(crate) mod test {
             name,
             true,
             false,
-            vec!["sha1", "sha256", "md5", "aws-etag-1gib", "crc32", "crc32c"],
+            vec![
+                "sha1",
+                "sha256",
+                "sha512",
+                "md5",
+                "aws-etag-1gib",
+                "crc32",
+                "crc32c",
+                "crc64nvme",
+                "xxhash64",
+                "xxhash3",
+                "xxhash128",
+            ],
             EXPECTED_MD5_SUM,
         )
         .await
@@ -508,7 +521,18 @@ pub(crate) mod test {
             name,
             false,
             true,
-            vec!["sha1", "sha256", "aws-etag-1gib", "crc32", "crc32c"],
+            vec![
+                "sha1",
+                "sha256",
+                "sha512",
+                "aws-etag-1gib",
+                "crc32",
+                "crc32c",
+                "crc64nvme",
+                "xxhash64",
+                "xxhash3",
+                "xxhash128",
+            ],
             EXPECTED_MD5_SUM,
         )
         .await
@@ -523,7 +547,18 @@ pub(crate) mod test {
             name,
             false,
             false,
-            vec!["sha1", "sha256", "aws-etag-1gib", "crc32", "crc32c"],
+            vec![
+                "sha1",
+                "sha256",
+                "sha512",
+                "aws-etag-1gib",
+                "crc32",
+                "crc32c",
+                "crc64nvme",
+                "xxhash64",
+                "xxhash3",
+                "xxhash128",
+            ],
             "123",
         )
         .await
@@ -587,6 +622,22 @@ pub(crate) mod test {
             Checksum::new(EXPECTED_SHA256_SUM.to_string())
         );
         assert_eq!(
+            file.checksums[&"sha512".parse()?],
+            Checksum::new(EXPECTED_SHA512_SUM.to_string())
+        );
+        assert_eq!(
+            file.checksums[&"xxhash64".parse()?],
+            Checksum::new(EXPECTED_XXHASH64_SUM.to_string())
+        );
+        assert_eq!(
+            file.checksums[&"xxhash3".parse()?],
+            Checksum::new(EXPECTED_XXHASH3_SUM.to_string())
+        );
+        assert_eq!(
+            file.checksums[&"xxhash128".parse()?],
+            Checksum::new(EXPECTED_XXHASH128_SUM.to_string())
+        );
+        assert_eq!(
             file.checksums[&"md5-aws-1073741824b".parse()?],
             Checksum::new(expected_md5_1gib().to_string())
         );
@@ -597,6 +648,10 @@ pub(crate) mod test {
         assert_eq!(
             file.checksums[&"crc32c".parse()?],
             Checksum::new(EXPECTED_CRC32C_BE_SUM.to_string())
+        );
+        assert_eq!(
+            file.checksums[&"crc64nvme".parse()?],
+            Checksum::new(EXPECTED_CRC64NVME_BE_SUM.to_string())
         );
 
         Ok(())


### PR DESCRIPTION
This is a leftover from https://github.com/umccr/copyrite/pull/99.

It adds the missing md5 logic for the AWS parts computation, and also adds missing checksums to tests