### PR TITLE
feat: add debian/rpm changelog and package regeneration

### DIFF
--- a/.github/workflows/release-crate.yml
+++ b/.github/workflows/release-crate.yml
@@ -21,6 +21,27 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
+        id: release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # This control regenerating the debian/rpm packages when release-plz creates a PR.
+      - name: Check out the release PR branch
+        if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ fromJSON(steps.release-plz.outputs.pr).head_branch }}
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Regenerate packaging changelogs
+        if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo xtask changelog
+      - name: Commit packaging changelogs to the release PR
+        if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "chore: regenerate Debian and RPM changelogs"
+          file_pattern: pkg/debian/changelog pkg/rpm/copyrite.spec
+          branch: ${{ fromJSON(steps.release-plz.outputs.pr).head_branch }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +31,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anes"
@@ -98,6 +113,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +132,18 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -554,7 +593,7 @@ dependencies = [
  "regex-lite",
  "roxmltree",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -692,6 +731,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -711,6 +756,35 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bitflags"
@@ -746,6 +820,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +849,33 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
+]
+
+[[package]]
+name = "cacache"
+version = "13.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b"
+dependencies = [
+ "digest 0.10.7",
+ "either",
+ "futures",
+ "hex",
+ "libc",
+ "memmap2",
+ "miette",
+ "reflink-copy",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "ssri",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "walkdir",
 ]
 
 [[package]]
@@ -811,6 +922,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,7 +944,34 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -881,6 +1025,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +1050,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "cmake"
@@ -920,6 +1083,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "config"
+version = "0.15.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
+dependencies = [
+ "pathdiff",
+ "serde_core",
+ "toml 1.1.3+spec-1.1.0",
+ "winnow 1.0.4",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +1120,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -958,7 +1151,7 @@ dependencies = [
  "aws-smithy-mocks",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "clap",
  "console",
@@ -978,13 +1171,13 @@ dependencies = [
  "md-5",
  "parse-size",
  "pastey",
- "rand",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha1 0.11.0",
  "sha2 0.11.0",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "xxhash-rust",
@@ -1184,6 +1377,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1407,12 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "diff"
@@ -1237,6 +1442,27 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1315,6 +1541,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1571,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
  "windows-sys 0.61.2",
 ]
 
@@ -1395,12 +1640,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1408,6 +1669,23 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
@@ -1438,9 +1716,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1463,8 +1745,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1474,9 +1758,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1491,6 +1777,125 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "git-cliff"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eec356762da51061234394f37fc66e911839fd7e994610bfcb7791a4ee76cac"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "clap_mangen",
+ "etcetera",
+ "git-cliff-core",
+ "glob",
+ "indicatif",
+ "owo-colors",
+ "pathdiff",
+ "regex",
+ "reqwest",
+ "secrecy",
+ "shellexpand",
+ "tracing",
+ "tracing-indicatif",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "git-cliff-core"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f084fe5556719bddf18730c5cdd0294da71169876d4022970838b165fa9b1f"
+dependencies = [
+ "async-stream",
+ "bincode 2.0.1",
+ "cacache",
+ "chrono",
+ "config",
+ "dyn-clone",
+ "etcetera",
+ "futures",
+ "git-conventional",
+ "git2",
+ "glob",
+ "http-cache-reqwest",
+ "indexmap",
+ "next_version",
+ "regex",
+ "reqwest",
+ "reqwest-middleware",
+ "rust-embed",
+ "secrecy",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "tera",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "tracing-indicatif",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
+name = "git-conventional"
+version = "0.12.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a949b7fcc81df22526032dcddb006e78c8575e47b0e7ba57d9960570a57bc4"
+dependencies = [
+ "serde",
+ "unicase",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -1580,6 +1985,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +2079,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-cache"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e883defacf53960c7717d9e928dc8667be9501d9f54e6a8b7703d7a30320e9c"
+dependencies = [
+ "async-trait",
+ "bincode 1.3.3",
+ "cacache",
+ "http 1.4.1",
+ "http-cache-semantics",
+ "httpdate",
+ "serde",
+ "url",
+]
+
+[[package]]
+name = "http-cache-reqwest"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076afd9d376f09073b515ce95071b29393687d98ed521948edb899195595ddf"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.1",
+ "http-cache",
+ "http-cache-semantics",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "url",
+]
+
+[[package]]
+name = "http-cache-semantics"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4311240f94cb6fe622337dc580b09ddd6ae4a891eb121dba20cf4f77ca4e7129"
+dependencies = [
+ "http 1.4.1",
+ "http-serde",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http 1.4.1",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +2144,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -1765,6 +2243,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1773,7 +2252,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1788,6 +2267,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1900,6 +2403,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "include-flate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f173716febb1ad596c16ea5637b5f1790ea32de8e627493ff82bc73b0876ce"
+dependencies = [
+ "include-flate-codegen",
+ "include-flate-compress",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a7875b62a72ad3f3203cdd8950d4cf9947db036030b974b8b37ceae90c8d8c0"
+dependencies = [
+ "include-flate-compress",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "include-flate-compress"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fbb9c5ccb9a5b67b4afa2974c27e5507ea1bf6d22828cef418e4dfaeca51dd"
+dependencies = [
+ "libflate",
+ "zstd",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,8 +2471,9 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unit-prefix",
+ "vt100",
  "web-time",
 ]
 
@@ -1992,6 +2545,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libflate"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+ "no_std_io2",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
+dependencies = [
+ "hashbrown 0.16.1",
+ "no_std_io2",
+ "rle-decode-fast",
+]
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.5+1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2635,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,6 +2666,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror 1.0.69",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,6 +2728,26 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "next_version"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc89399c10a3de3a18971b961e9fea788eb252d887c1c2f740f351a907088d0c"
+dependencies = [
+ "git-conventional",
+ "regex",
+ "semver",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2149,10 +2839,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p256"
@@ -2183,10 +2885,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2202,6 +2919,86 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2224,6 +3021,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -2275,6 +3078,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,12 +3116,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.5",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2335,6 +3224,27 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
@@ -2345,12 +3255,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2377,6 +3316,29 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
 ]
 
 [[package]]
@@ -2415,6 +3377,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.1",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +3457,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
+
+[[package]]
 name = "roxmltree"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,6 +3476,49 @@ checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
 dependencies = [
  "xmlparser",
 ]
+
+[[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "include-flate",
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "include-flate",
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2489,6 +3562,7 @@ checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -2513,6 +3587,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2589,6 +3664,16 @@ dependencies = [
  "generic-array",
  "pkcs8",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
  "zeroize",
 ]
 
@@ -2672,6 +3757,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2725,6 +3852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,10 +3887,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "smallvec"
@@ -2799,6 +3951,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssri"
+version = "9.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082"
+dependencies = [
+ "base64 0.21.7",
+ "digest 0.10.7",
+ "hex",
+ "miette",
+ "serde",
+ "sha-1",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,6 +3997,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,6 +4030,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tera"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "globwalk",
+ "humansize",
+ "lazy_static",
+ "percent-encoding",
+ "pest",
+ "pest_derive",
+ "rand 0.8.7",
+ "regex",
+ "serde",
+ "serde_json",
+ "slug",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2863,11 +4063,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2897,6 +4117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3003,6 +4224,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,13 +4248,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3067,6 +4388,18 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-indicatif"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ef6990e0438749f0080573248e96631171a0b5ddfddde119aa5ba8c3a9c47e"
+dependencies = [
+ "indicatif",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3124,10 +4457,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -3154,6 +4511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,6 +4526,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3200,16 +4564,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
 name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width 0.2.2",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"
@@ -3265,6 +4662,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3354,6 +4761,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,10 +4801,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3422,6 +4933,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3471,6 +4991,24 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -3579,10 +5117,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "xtask"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "git-cliff",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+
+[[package]]
+name = "yaml-rust2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+]
 
 [[package]]
 name = "yansi"
@@ -3698,3 +5256,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["copyrite"]
+members = ["copyrite", "xtask"]
 resolver = "3"
 
 [workspace.package]

--- a/pkg/cliff-debian.toml
+++ b/pkg/cliff-debian.toml
@@ -8,7 +8,6 @@ body = """copyrite ({{ version | trim_start_matches(pat="v") }}-1) unstable; urg
  -- Marko Malenic <mmalenic1@gmail.com>  {% set c = commits | first %}{{ c.committer.timestamp | date(format="%a, %d %b %Y %H:%M:%S %z", timezone="UTC") }}
 
 """
-footer = ""
 trim = false
 
 [git]

--- a/pkg/cliff-debian.toml
+++ b/pkg/cliff-debian.toml
@@ -1,0 +1,34 @@
+# git-cliff configuration that renders `pkg/debian/changelog` using `cargo xtask changelog`
+
+[changelog]
+body = """copyrite ({{ version | trim_start_matches(pat="v") }}-1) unstable; urgency=low
+
+{% for commit in commits %}  * {{ commit.message | split(pat="\n") | first | trim | upper_first }}{% if commit.remote.username %} (@{{ commit.remote.username }}){% endif %}
+{% endfor %}
+ -- Marko Malenic <mmalenic1@gmail.com>  {% set c = commits | first %}{{ c.committer.timestamp | date(format="%a, %d %b %Y %H:%M:%S %z", timezone="UTC") }}
+
+"""
+footer = ""
+trim = false
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_parsers = [
+  { message = "^Merge ", skip = true },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore: release", skip = true },
+  { message = "^chore\\(deps", skip = true },
+  { message = ".*", group = "changes" },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v?[0-9]*"
+skip_tags = ".*-rc.*"
+topo_order = false
+sort_commits = "newest"
+
+[remote.github]
+owner = "umccr"
+repo = "copyrite"

--- a/pkg/cliff-rpm.toml
+++ b/pkg/cliff-rpm.toml
@@ -5,7 +5,6 @@ body = """{% set c = commits | first %}* {{ c.committer.timestamp | date(format=
 {% for commit in commits %}- {{ commit.message | split(pat="\n") | first | trim | upper_first }}{% if commit.remote.username %} (@{{ commit.remote.username }}){% endif %}
 {% endfor %}
 """
-footer = ""
 trim = false
 
 [git]

--- a/pkg/cliff-rpm.toml
+++ b/pkg/cliff-rpm.toml
@@ -1,0 +1,31 @@
+# git-cliff configuration that renders RPM %changelog entries using `cargo xtask changelog`.
+
+[changelog]
+body = """{% set c = commits | first %}* {{ c.committer.timestamp | date(format="%a %b %d %Y", timezone="UTC") }} Marko Malenic <mmalenic1@gmail.com> - {{ version | trim_start_matches(pat="v") }}-1
+{% for commit in commits %}- {{ commit.message | split(pat="\n") | first | trim | upper_first }}{% if commit.remote.username %} (@{{ commit.remote.username }}){% endif %}
+{% endfor %}
+"""
+footer = ""
+trim = false
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_parsers = [
+  { message = "^Merge ", skip = true },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore: release", skip = true },
+  { message = "^chore\\(deps", skip = true },
+  { message = ".*", group = "changes" },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v?[0-9]*"
+skip_tags = ".*-rc.*"
+topo_order = false
+sort_commits = "newest"
+
+[remote.github]
+owner = "umccr"
+repo = "copyrite"

--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -1,50 +1,229 @@
 copyrite (0.7.0-1) unstable; urgency=low
 
-  * fix: pairing clients with their source/destination location properly by @mmalenic in https://github.com/umccr/copyrite/pull/97
+  * Add new checksums to tests and properly run md5 through parts (@mmalenic)
+  * Add md5 sum support and also fix encryption-based etag support (@mmalenic)
+  * Add checksum tests for md5, xxhash, sha512 (@mmalenic)
+  * Add xxhash variants, md5 and sha512 (@mmalenic)
+  * Add pkg changelogs (@mmalenic)
+  * Pairing clients with their source/destination location properly (@mmalenic)
+  * Update CHANGELOG to remove fixed entries (@andrewpatto)
+  * Fix clippy (@andrewpatto)
+  * Fix fmt (@andrewpatto)
+  * Introduced an option that disables request checksums (which had been enabled automatically in the AWS SDK) (@andrewpatto)
+  * Add release for 0.5.1, and use glibc 2.34 for greater compatibility (@mmalenic)
+  * Improve error print output (@mmalenic)
+  * Fmt (@mmalenic)
+  * Max object size should be 50 TiB not 5 TiB (@mmalenic)
+  * Add S3 tests for max size and single part check (@mmalenic)
+  * Add file based tests for append/truncate (@mmalenic)
+  * Avoid unnecessary clone on object info (@mmalenic)
+  * Append on existing data for file copy (@mmalenic)
+  * Correctly run upload tasks concurrently, single-part should be inclusive (@mmalenic)
+  * Add max object size setting (@mmalenic)
+  * Guard against invalid single-part copy attempts, and change < to <= in multipart detection (@mmalenic)
+  * Add test cases targeting retries and re-open (@mmalenic)
+  * Add bytes dependency (@mmalenic)
+  * Add re-open read for aws based operations (@mmalenic)
+  * Add re-open read for file based operations (@mmalenic)
+  * Make the CopyContent re-open function required (@mmalenic)
+  * Add streaming to multipart as well (@mmalenic)
+  * Apply reopen logic to avoid holding memory while using put object (@mmalenic)
+  * Add with_reopen to copy when using best effort copying (@mmalenic)
+  * Add re-open handle to allow re-fetching the source when required (@mmalenic)
 
- -- Marko Malenic <mmalenic1@gmail.com>  Mon, 21 Jul 2026 00:00:00 +0000
-
-copyrite (0.6.0-1) unstable; urgency=low
-
-  * fix: option to disable request checksums by @andrewpatto in https://github.com/umccr/copyrite/pull/94
-
- -- Marko Malenic <mmalenic1@gmail.com>  Wed, 16 Jul 2026 00:00:00 +0000
-
-copyrite (0.5.1-1) unstable; urgency=low
-
-  * feat: improve error print output by @mmalenic in https://github.com/umccr/copyrite/pull/87
-
- -- Marko Malenic <mmalenic1@gmail.com>  Fri, 03 Jul 2026 00:00:00 +0000
-
-copyrite (0.5.0-1) unstable; urgency=low
-
-  * fix: in-memory bytes by @mmalenic in https://github.com/umccr/copyrite/pull/79
-  * fix: max part size copy by @mmalenic in https://github.com/umccr/copyrite/pull/82
-
- -- Marko Malenic <mmalenic1@gmail.com>  Thu, 04 June 2026 00:00:00 +0000
+ -- Marko Malenic <mmalenic1@gmail.com>  Wed, 22 Jul 2026 02:54:42 +0000
 
 copyrite (0.4.0-1) unstable; urgency=low
 
-  * ci: check if assets are found on release by @mmalenic in https://github.com/umccr/copyrite/pull/73
-  * ci: docker.yml needs to use the same tag logic as release-bins.yml by @mmalenic in https://github.com/umccr/copyrite/pull/74
-  * feat: stalled stream override by @mmalenic in https://github.com/umccr/copyrite/pull/75
+  * Format pkg release (@mmalenic)
+  * Add overrides for other S3 operations (@mmalenic)
+  * Use wrapper functions when calling S3 (@mmalenic)
+  * Add wrapper calls to s3 client with overrides (@mmalenic)
+  * Add SSP override options (@mmalenic)
+  * Docker.yml needs to use the same tag logic as release-bins.yml (@mmalenic)
+  * Check if assets are found on the release before attempting the workflow, as release-plz completes before and after publishing (@mmalenic)
 
- -- Marko Malenic <mmalenic1@gmail.com>  Tue, 12 May 2026 00:00:00 +0000
+ -- Marko Malenic <mmalenic1@gmail.com>  Tue, 12 May 2026 04:20:04 +0000
 
 copyrite (0.3.2-1) unstable; urgency=low
 
-  * Release 0.3.2
+  * Rename variable (@mmalenic)
+  * Adjust workflow to trigger on workflow_run (@mmalenic)
 
- -- Marko Malenic <mmalenic1@gmail.com>  Fri, 10 Apr 2026 00:00:00 +0000
+ -- Marko Malenic <mmalenic1@gmail.com>  Fri, 10 Apr 2026 09:02:56 +0000
 
-copyrite (0.3.0-1) unstable; urgency=low
+copyrite (0.3.1-1) unstable; urgency=low
 
-  * Release 0.3.0
+  * Also update changelog for pkg files (@mmalenic)
+  * Use types published and avoid creating a separate release (@mmalenic)
+  * Use trusted publishing (@mmalenic)
 
- -- Marko Malenic <mmalenic1@gmail.com>  Fri, 10 Apr 2026 00:00:00 +0000
+ -- Marko Malenic <mmalenic1@gmail.com>  Fri, 10 Apr 2026 06:59:45 +0000
+
+copyrite (0.2.5-1) unstable; urgency=low
+
+  * Add option to avoid `GetObjectAttributes` (@mmalenic)
+  * Fix determining copy mode settings (@mmalenic)
+  * Fix mocked AWS calls (@mmalenic)
+  * Allow setting clients per object for check/generate (@mmalenic)
+  * Make GetObjectAttributes failure recoverable and return in api errors (@mmalenic)
+  * Further improve AWS error message context (@mmalenic)
+  * Add more error context (@mmalenic)
+  * Implement source/destination credentials, endpoint urls, profiles and regions (@mmalenic)
+  * Trying client creation (@andrewpatto)
+  * Added some extra ignores (@andrewpatto)
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Sun, 11 May 2025 23:48:54 +0000
+
+copyrite (0.2.4-1) unstable; urgency=low
+
+  * Format errors as json (@mmalenic)
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Fri, 02 May 2025 06:38:45 +0000
+
+copyrite (0.2.3-1) unstable; urgency=low
+
+  * Don't write sums by default, add `--write-sums-file` option and `--missing` option to check (@mmalenic)
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Fri, 02 May 2025 02:30:19 +0000
+
+copyrite (0.2.2-1) unstable; urgency=low
+
+  * Add sums mismatch option for stats (@mmalenic)
+  * Add descriptions of fields generated in stats (@mmalenic)
+  * Add skipped option to copy to avoid copying unnecessarily (@mmalenic)
+  * Add copy command stats (@mmalenic)
+  * Add generate stats output (@mmalenic)
+  * Adjust reason field in compared values (@mmalenic)
+  * Check command updated stats (@mmalenic)
+  * Adjust default part size when left unspecified for generate (@mmalenic)
+  * Implement check command stats (@mmalenic)
+  * Create structs for output stats (@mmalenic)
+  * Move free-standing cli functions to structs (@mmalenic)
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Wed, 30 Apr 2025 06:56:21 +0000
+
+copyrite (0.2.1-1) unstable; urgency=low
+
+  * Parsing part size off multipart sum manually and adding crc64nvme to all calls (@mmalenic)
+  * Add nvme crc64 (@mmalenic)
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Thu, 17 Apr 2025 04:57:49 +0000
+
+copyrite (0.2.0-1) unstable; urgency=low
+
+  * Macro in part size position to avoid repetition (@mmalenic)
+  * Use array with constant byte sizes (@mmalenic)
+  * Change multipart threshold (@mmalenic)
+  * Is_copy and is_best_effort to avoid confusion (@mmalenic)
+  * Initialize s3 client only once (@mmalenic)
+  * Remove mutexes and add integration tests (@mmalenic)
+  * Copy with check and generate output (@mmalenic)
+  * Add additional checksums to copied files (@mmalenic)
+  * Add check/generate to copy command to confirm copy (@mmalenic)
+  * Add concurrency to copies (@mmalenic)
+  * Implement multipart copies in loop (@mmalenic)
+  * Add tests for multipart/single part settings detection (@mmalenic)
+  * Add preferred checksum part size detection (@mmalenic)
+  * Add multipart uploads (@mmalenic)
+  * Add copy_object in parts functionality (@mmalenic)
+  * Add ordering of ideal part sizes (@mmalenic)
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Thu, 17 Apr 2025 02:56:25 +0000
 
 copyrite (0.1.0-1) unstable; urgency=low
 
-  * Initial release
+  * 'tar: none' has the side effect of 'upload-rust-binary-action/v1/main.sh: line 493: assets[@]: unbound variable'... we'll have to live with tarballs per platform for now (@brainstorm)
+  * Rename release-bins workflow accordingly (instead of tests) (@brainstorm)
+  * Target is arch target, not bin target (@brainstorm)
+  * Re-enable tests workflow pre-pr-merge (@brainstorm)
+  * Removing cargo-bloat since it failed unexpectedly, should be moved to a separate 'audit' workflow anyway (@brainstorm)
+  * Separate workflows by concern, remove release-plz one (for now, until a name for the project is decided?) (@brainstorm)
+  * No changelog yet (@brainstorm)
+  * Skip tests for now, do any of the taiki-e actions 'cargo build'? (@brainstorm)
+  * Bump mozilla actions sccache (see https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts) (@brainstorm)
+  * No release-plz for Andrew :) (@brainstorm)
+  * First cut at releasing binaries (and crate) as suggested in https://github.com/umccr/cloud-checksum/issues/29 by @andrewpatto (@brainstorm)
+  * Retry logic for access denied errors on tagging (@mmalenic)
+  * Add separate option for tag mode vs metadata mode (@mmalenic)
+  * Add option to force download-upload mode (@mmalenic)
+  * Copy operations and tagging (@mmalenic)
+  * Add metadata copy mode (@mmalenic)
+  * Remove ordering of ctx changes (@mmalenic)
+  * Implement single-part copy (@mmalenic)
+  * Tidy trait seperation using copy and sums (@mmalenic)
+  * Move url parsing to provider (@mmalenic)
+  * Add single-part copies (@mmalenic)
+  * Decide on the "best" ordering for aws and standard checksums (@mmalenic)
+  * Separate reader/write in IO (@mmalenic)
+  * Copy command options (@mmalenic)
+  * Simplify .sums file to remove unnecessary part checksums (@mmalenic)
+  * Re-work canonical form of aws etag to include byte size (@mmalenic)
+  * Allow specifying different part sizes for aws checksums (@mmalenic)
+  * Aws decode additional checksums and use generate for tests (@mmalenic)
+  * Simplify version string to a single number (@mmalenic)
+  * Use head object for calculating parts for etags (@mmalenic)
+  * Re-work part checksums so that the part size is nested inside a part checksum to support arbitrary part sizes (@mmalenic)
+  * Add method to add AWS checksums and consider the full/composite checksum type in the SDK (@mmalenic)
+  * Add checksums from object attributes (@mmalenic)
+  * Fetch existing sums files from S3 (@mmalenic)
+  * Add s3 url parsing logic (@mmalenic)
+  * Remove cloud module and add to reader instead (@mmalenic)
+  * Construct sums ctx using function and fix aws endianness (@mmalenic)
+  * Enable generate and check logic for metadata-only sums (@mmalenic)
+  * Merge metadata checksums with existing sums on S3 side (@mmalenic)
+  * Link up S3 sums logic with the rest of the code (@mmalenic)
+  * Add into async read for the S3 reader (@mmalenic)
+  * Avoid using serde_with for now (@mmalenic)
+  * Skip empty optionals (@mmalenic)
+  * Random thoughts (@andrewpatto)
+  * Use single-line non-pretty json formatting (@mmalenic)
+  * Aws etag syntax and logic (@mmalenic)
+  * Crc32 and crc32-le should hash differently (@mmalenic)
+  * Allow commands to work with empty or missing sums files (@mmalenic)
+  * Add check output struct (@mmalenic)
+  * Part number should be the canonical form for aws-style checksums (@mmalenic)
+  * Add equality and comparability tests (@mmalenic)
+  * Add generate missing option (@mmalenic)
+  * Add generate missing arg and allow specifying multiple input files for generate (@mmalenic)
+  * Add update from check option (@mmalenic)
+  * Add set-based check command (@mmalenic)
+  * Implement check command from .sums files (@mmalenic)
+  * Add part-number style etag parsing (@mmalenic)
+  * Separate regular and AWS checksums (@mmalenic)
+  * Add tests for aws checksums (@mmalenic)
+  * Link up CLI options with aws etag checksummer algorithm (@mmalenic)
+  * Add part checksummer (@mmalenic)
+  * Add checksum algorithm with part size struct (@mmalenic)
+  * Add tests for verify, overwrite, and no-verify modes (@mmalenic)
+  * Add verify flag, use "-" instead of "--stdin", add version and remove name from output file, overwrite when merging (@mmalenic)
+  * Use kebab-case because that's what checksum names will be based on (@mmalenic)
+  * Add ability to append to existing checksums file and option to force overwrite (@mmalenic)
+  * Rework input to use position arg as default and pass --stdin for stdin (@mmalenic)
+  * Add output file and write checksums instead of printing (@mmalenic)
+  * Add single-part aws-etag CLI parsing and calculation (@mmalenic)
+  * Add definition for output file (@mmalenic)
+  * Add -le and -be extension to enum variants on CLI (@mmalenic)
+  * Add crc32c checksum (@mmalenic)
+  * Add crc32 checksum (@mmalenic)
+  * Generate test file with mutex guard so tests can run in parallel (@mmalenic)
+  * Add test action (@mmalenic)
+  * Use multiple mpsc channels to fix slow receiver (@mmalenic)
+  * Add some unit tests and update test file generator (@mmalenic)
+  * Add test file generating module (@mmalenic)
+  * Add chunk size configuration to reader (@mmalenic)
+  * Use async_channel, as it seems to perform better and have a simpler unbounded implementation (@mmalenic)
+  * Refine benchmarks and avoid lagging receiver (@mmalenic)
+  * Add benchmarks for channel reader (@mmalenic)
+  * Create task executor, confine channels to channel reader, and perform checksum task in checksum enum (@mmalenic)
+  * Add reader structs and refine task types (@mmalenic)
+  * Refine check command arguments (@mmalenic)
+  * Add some subcommands and rename package (@mmalenic)
+  * Add explaining comments (@mmalenic)
+  * Add basic outline of concurrent checksums (@mmalenic)
+  * Add basic skeleton with argument parsing (@mmalenic)
+  * Initial commit (@andrewpatto)
 
- -- Marko Malenic <mmalenic1@gmail.com>  Mon, 13 Oct 2025 00:00:00 +0000
+ -- Marko Malenic <mmalenic1@gmail.com>  Tue, 15 Apr 2025 22:48:40 +0000
+
+

--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -1,17 +1,38 @@
-copyrite (0.7.0-1) unstable; urgency=low
+copyrite (0.8.0-1) unstable; urgency=low
 
+  * Add debian/rpm changelog and package regeneration
   * Add new checksums to tests and properly run md5 through parts (@mmalenic)
   * Add md5 sum support and also fix encryption-based etag support (@mmalenic)
   * Add checksum tests for md5, xxhash, sha512 (@mmalenic)
   * Add xxhash variants, md5 and sha512 (@mmalenic)
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Wed, 22 Jul 2026 22:32:25 +0000
+
+copyrite (0.7.0-1) unstable; urgency=low
+
   * Add pkg changelogs (@mmalenic)
   * Pairing clients with their source/destination location properly (@mmalenic)
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Sun, 19 Jul 2026 23:39:33 +0000
+
+copyrite (0.6.0-1) unstable; urgency=low
+
   * Update CHANGELOG to remove fixed entries (@andrewpatto)
   * Fix clippy (@andrewpatto)
   * Fix fmt (@andrewpatto)
   * Introduced an option that disables request checksums (which had been enabled automatically in the AWS SDK) (@andrewpatto)
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Thu, 16 Jul 2026 05:51:26 +0000
+
+copyrite (0.5.1-1) unstable; urgency=low
+
   * Add release for 0.5.1, and use glibc 2.34 for greater compatibility (@mmalenic)
   * Improve error print output (@mmalenic)
+
+ -- Marko Malenic <mmalenic1@gmail.com>  Fri, 03 Jul 2026 05:31:58 +0000
+
+copyrite (0.5.0-1) unstable; urgency=low
+
   * Fmt (@mmalenic)
   * Max object size should be 50 TiB not 5 TiB (@mmalenic)
   * Add S3 tests for max size and single part check (@mmalenic)
@@ -31,7 +52,7 @@ copyrite (0.7.0-1) unstable; urgency=low
   * Add with_reopen to copy when using best effort copying (@mmalenic)
   * Add re-open handle to allow re-fetching the source when required (@mmalenic)
 
- -- Marko Malenic <mmalenic1@gmail.com>  Wed, 22 Jul 2026 02:54:42 +0000
+ -- Marko Malenic <mmalenic1@gmail.com>  Wed, 03 Jun 2026 21:41:53 +0000
 
 copyrite (0.4.0-1) unstable; urgency=low
 
@@ -225,5 +246,3 @@ copyrite (0.1.0-1) unstable; urgency=low
   * Initial commit (@andrewpatto)
 
  -- Marko Malenic <mmalenic1@gmail.com>  Tue, 15 Apr 2025 22:48:40 +0000
-
-

--- a/pkg/rpm/copyrite.spec
+++ b/pkg/rpm/copyrite.spec
@@ -23,19 +23,28 @@ install -D target/release/%{name} %{buildroot}%{_bindir}/%{name}
 %{_bindir}/%{name}
 
 %changelog
-* Wed Jul 22 2026 Marko Malenic <mmalenic1@gmail.com> - 0.7.0-1
+* Wed Jul 22 2026 Marko Malenic <mmalenic1@gmail.com> - 0.8.0-1
+- Add debian/rpm changelog and package regeneration
 - Add new checksums to tests and properly run md5 through parts (@mmalenic)
 - Add md5 sum support and also fix encryption-based etag support (@mmalenic)
 - Add checksum tests for md5, xxhash, sha512 (@mmalenic)
 - Add xxhash variants, md5 and sha512 (@mmalenic)
+
+* Sun Jul 19 2026 Marko Malenic <mmalenic1@gmail.com> - 0.7.0-1
 - Add pkg changelogs (@mmalenic)
 - Pairing clients with their source/destination location properly (@mmalenic)
+
+* Thu Jul 16 2026 Marko Malenic <mmalenic1@gmail.com> - 0.6.0-1
 - Update CHANGELOG to remove fixed entries (@andrewpatto)
 - Fix clippy (@andrewpatto)
 - Fix fmt (@andrewpatto)
 - Introduced an option that disables request checksums (which had been enabled automatically in the AWS SDK) (@andrewpatto)
+
+* Fri Jul 03 2026 Marko Malenic <mmalenic1@gmail.com> - 0.5.1-1
 - Add release for 0.5.1, and use glibc 2.34 for greater compatibility (@mmalenic)
 - Improve error print output (@mmalenic)
+
+* Wed Jun 03 2026 Marko Malenic <mmalenic1@gmail.com> - 0.5.0-1
 - Fmt (@mmalenic)
 - Max object size should be 50 TiB not 5 TiB (@mmalenic)
 - Add S3 tests for max size and single part check (@mmalenic)
@@ -217,5 +226,3 @@ install -D target/release/%{name} %{buildroot}%{_bindir}/%{name}
 - Add basic outline of concurrent checksums (@mmalenic)
 - Add basic skeleton with argument parsing (@mmalenic)
 - Initial commit (@andrewpatto)
-
-

--- a/pkg/rpm/copyrite.spec
+++ b/pkg/rpm/copyrite.spec
@@ -23,29 +23,199 @@ install -D target/release/%{name} %{buildroot}%{_bindir}/%{name}
 %{_bindir}/%{name}
 
 %changelog
-* Mon Jul 21 2026 Marko Malenic <mmalenic1@gmail.com> - 0.7.0-1
-- fix: pairing clients with their source/destination location properly by @mmalenic in https://github.com/umccr/copyrite/pull/97
-
-* Wed Jul 16 2026 Marko Malenic <mmalenic1@gmail.com> - 0.6.0-1
-- fix: option to disable request checksums by @andrewpatto in https://github.com/umccr/copyrite/pull/94
-
-* Fri Jul 03 2026 Marko Malenic <mmalenic1@gmail.com> - 0.5.1-1
-- feat: improve error print output by @mmalenic in https://github.com/umccr/copyrite/pull/87
-
-* Thu Jun 04 2026 Marko Malenic <mmalenic1@gmail.com> - 0.5.0-1
-- fix: in-memory bytes by @mmalenic in https://github.com/umccr/copyrite/pull/79
-- fix: max part size copy by @mmalenic in https://github.com/umccr/copyrite/pull/82
+* Wed Jul 22 2026 Marko Malenic <mmalenic1@gmail.com> - 0.7.0-1
+- Add new checksums to tests and properly run md5 through parts (@mmalenic)
+- Add md5 sum support and also fix encryption-based etag support (@mmalenic)
+- Add checksum tests for md5, xxhash, sha512 (@mmalenic)
+- Add xxhash variants, md5 and sha512 (@mmalenic)
+- Add pkg changelogs (@mmalenic)
+- Pairing clients with their source/destination location properly (@mmalenic)
+- Update CHANGELOG to remove fixed entries (@andrewpatto)
+- Fix clippy (@andrewpatto)
+- Fix fmt (@andrewpatto)
+- Introduced an option that disables request checksums (which had been enabled automatically in the AWS SDK) (@andrewpatto)
+- Add release for 0.5.1, and use glibc 2.34 for greater compatibility (@mmalenic)
+- Improve error print output (@mmalenic)
+- Fmt (@mmalenic)
+- Max object size should be 50 TiB not 5 TiB (@mmalenic)
+- Add S3 tests for max size and single part check (@mmalenic)
+- Add file based tests for append/truncate (@mmalenic)
+- Avoid unnecessary clone on object info (@mmalenic)
+- Append on existing data for file copy (@mmalenic)
+- Correctly run upload tasks concurrently, single-part should be inclusive (@mmalenic)
+- Add max object size setting (@mmalenic)
+- Guard against invalid single-part copy attempts, and change < to <= in multipart detection (@mmalenic)
+- Add test cases targeting retries and re-open (@mmalenic)
+- Add bytes dependency (@mmalenic)
+- Add re-open read for aws based operations (@mmalenic)
+- Add re-open read for file based operations (@mmalenic)
+- Make the CopyContent re-open function required (@mmalenic)
+- Add streaming to multipart as well (@mmalenic)
+- Apply reopen logic to avoid holding memory while using put object (@mmalenic)
+- Add with_reopen to copy when using best effort copying (@mmalenic)
+- Add re-open handle to allow re-fetching the source when required (@mmalenic)
 
 * Tue May 12 2026 Marko Malenic <mmalenic1@gmail.com> - 0.4.0-1
-- ci: check if assets are found on release by @mmalenic in https://github.com/umccr/copyrite/pull/73
-- ci: docker.yml needs to use the same tag logic as release-bins.yml by @mmalenic in https://github.com/umccr/copyrite/pull/74
-- feat: stalled stream override by @mmalenic in https://github.com/umccr/copyrite/pull/75
+- Format pkg release (@mmalenic)
+- Add overrides for other S3 operations (@mmalenic)
+- Use wrapper functions when calling S3 (@mmalenic)
+- Add wrapper calls to s3 client with overrides (@mmalenic)
+- Add SSP override options (@mmalenic)
+- Docker.yml needs to use the same tag logic as release-bins.yml (@mmalenic)
+- Check if assets are found on the release before attempting the workflow, as release-plz completes before and after publishing (@mmalenic)
+
+* Fri Apr 10 2026 Marko Malenic <mmalenic1@gmail.com> - 0.3.2-1
+- Rename variable (@mmalenic)
+- Adjust workflow to trigger on workflow_run (@mmalenic)
 
 * Fri Apr 10 2026 Marko Malenic <mmalenic1@gmail.com> - 0.3.1-1
-- Release 0.3.1
+- Also update changelog for pkg files (@mmalenic)
+- Use types published and avoid creating a separate release (@mmalenic)
+- Use trusted publishing (@mmalenic)
 
-* Fri Apr 10 2026 Marko Malenic <mmalenic1@gmail.com> - 0.3.0-1
-- Release 0.3.0
+* Sun May 11 2025 Marko Malenic <mmalenic1@gmail.com> - 0.2.5-1
+- Add option to avoid `GetObjectAttributes` (@mmalenic)
+- Fix determining copy mode settings (@mmalenic)
+- Fix mocked AWS calls (@mmalenic)
+- Allow setting clients per object for check/generate (@mmalenic)
+- Make GetObjectAttributes failure recoverable and return in api errors (@mmalenic)
+- Further improve AWS error message context (@mmalenic)
+- Add more error context (@mmalenic)
+- Implement source/destination credentials, endpoint urls, profiles and regions (@mmalenic)
+- Trying client creation (@andrewpatto)
+- Added some extra ignores (@andrewpatto)
 
-* Wed Oct 22 2025 Marko Malenic <mmalenic1@gmail.com> - 0.1.0-1
-- Initial package
+* Fri May 02 2025 Marko Malenic <mmalenic1@gmail.com> - 0.2.4-1
+- Format errors as json (@mmalenic)
+
+* Fri May 02 2025 Marko Malenic <mmalenic1@gmail.com> - 0.2.3-1
+- Don't write sums by default, add `--write-sums-file` option and `--missing` option to check (@mmalenic)
+
+* Wed Apr 30 2025 Marko Malenic <mmalenic1@gmail.com> - 0.2.2-1
+- Add sums mismatch option for stats (@mmalenic)
+- Add descriptions of fields generated in stats (@mmalenic)
+- Add skipped option to copy to avoid copying unnecessarily (@mmalenic)
+- Add copy command stats (@mmalenic)
+- Add generate stats output (@mmalenic)
+- Adjust reason field in compared values (@mmalenic)
+- Check command updated stats (@mmalenic)
+- Adjust default part size when left unspecified for generate (@mmalenic)
+- Implement check command stats (@mmalenic)
+- Create structs for output stats (@mmalenic)
+- Move free-standing cli functions to structs (@mmalenic)
+
+* Thu Apr 17 2025 Marko Malenic <mmalenic1@gmail.com> - 0.2.1-1
+- Parsing part size off multipart sum manually and adding crc64nvme to all calls (@mmalenic)
+- Add nvme crc64 (@mmalenic)
+
+* Thu Apr 17 2025 Marko Malenic <mmalenic1@gmail.com> - 0.2.0-1
+- Macro in part size position to avoid repetition (@mmalenic)
+- Use array with constant byte sizes (@mmalenic)
+- Change multipart threshold (@mmalenic)
+- Is_copy and is_best_effort to avoid confusion (@mmalenic)
+- Initialize s3 client only once (@mmalenic)
+- Remove mutexes and add integration tests (@mmalenic)
+- Copy with check and generate output (@mmalenic)
+- Add additional checksums to copied files (@mmalenic)
+- Add check/generate to copy command to confirm copy (@mmalenic)
+- Add concurrency to copies (@mmalenic)
+- Implement multipart copies in loop (@mmalenic)
+- Add tests for multipart/single part settings detection (@mmalenic)
+- Add preferred checksum part size detection (@mmalenic)
+- Add multipart uploads (@mmalenic)
+- Add copy_object in parts functionality (@mmalenic)
+- Add ordering of ideal part sizes (@mmalenic)
+
+* Tue Apr 15 2025 Marko Malenic <mmalenic1@gmail.com> - 0.1.0-1
+- 'tar: none' has the side effect of 'upload-rust-binary-action/v1/main.sh: line 493: assets[@]: unbound variable'... we'll have to live with tarballs per platform for now (@brainstorm)
+- Rename release-bins workflow accordingly (instead of tests) (@brainstorm)
+- Target is arch target, not bin target (@brainstorm)
+- Re-enable tests workflow pre-pr-merge (@brainstorm)
+- Removing cargo-bloat since it failed unexpectedly, should be moved to a separate 'audit' workflow anyway (@brainstorm)
+- Separate workflows by concern, remove release-plz one (for now, until a name for the project is decided?) (@brainstorm)
+- No changelog yet (@brainstorm)
+- Skip tests for now, do any of the taiki-e actions 'cargo build'? (@brainstorm)
+- Bump mozilla actions sccache (see https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts) (@brainstorm)
+- No release-plz for Andrew :) (@brainstorm)
+- First cut at releasing binaries (and crate) as suggested in https://github.com/umccr/cloud-checksum/issues/29 by @andrewpatto (@brainstorm)
+- Retry logic for access denied errors on tagging (@mmalenic)
+- Add separate option for tag mode vs metadata mode (@mmalenic)
+- Add option to force download-upload mode (@mmalenic)
+- Copy operations and tagging (@mmalenic)
+- Add metadata copy mode (@mmalenic)
+- Remove ordering of ctx changes (@mmalenic)
+- Implement single-part copy (@mmalenic)
+- Tidy trait seperation using copy and sums (@mmalenic)
+- Move url parsing to provider (@mmalenic)
+- Add single-part copies (@mmalenic)
+- Decide on the "best" ordering for aws and standard checksums (@mmalenic)
+- Separate reader/write in IO (@mmalenic)
+- Copy command options (@mmalenic)
+- Simplify .sums file to remove unnecessary part checksums (@mmalenic)
+- Re-work canonical form of aws etag to include byte size (@mmalenic)
+- Allow specifying different part sizes for aws checksums (@mmalenic)
+- Aws decode additional checksums and use generate for tests (@mmalenic)
+- Simplify version string to a single number (@mmalenic)
+- Use head object for calculating parts for etags (@mmalenic)
+- Re-work part checksums so that the part size is nested inside a part checksum to support arbitrary part sizes (@mmalenic)
+- Add method to add AWS checksums and consider the full/composite checksum type in the SDK (@mmalenic)
+- Add checksums from object attributes (@mmalenic)
+- Fetch existing sums files from S3 (@mmalenic)
+- Add s3 url parsing logic (@mmalenic)
+- Remove cloud module and add to reader instead (@mmalenic)
+- Construct sums ctx using function and fix aws endianness (@mmalenic)
+- Enable generate and check logic for metadata-only sums (@mmalenic)
+- Merge metadata checksums with existing sums on S3 side (@mmalenic)
+- Link up S3 sums logic with the rest of the code (@mmalenic)
+- Add into async read for the S3 reader (@mmalenic)
+- Avoid using serde_with for now (@mmalenic)
+- Skip empty optionals (@mmalenic)
+- Random thoughts (@andrewpatto)
+- Use single-line non-pretty json formatting (@mmalenic)
+- Aws etag syntax and logic (@mmalenic)
+- Crc32 and crc32-le should hash differently (@mmalenic)
+- Allow commands to work with empty or missing sums files (@mmalenic)
+- Add check output struct (@mmalenic)
+- Part number should be the canonical form for aws-style checksums (@mmalenic)
+- Add equality and comparability tests (@mmalenic)
+- Add generate missing option (@mmalenic)
+- Add generate missing arg and allow specifying multiple input files for generate (@mmalenic)
+- Add update from check option (@mmalenic)
+- Add set-based check command (@mmalenic)
+- Implement check command from .sums files (@mmalenic)
+- Add part-number style etag parsing (@mmalenic)
+- Separate regular and AWS checksums (@mmalenic)
+- Add tests for aws checksums (@mmalenic)
+- Link up CLI options with aws etag checksummer algorithm (@mmalenic)
+- Add part checksummer (@mmalenic)
+- Add checksum algorithm with part size struct (@mmalenic)
+- Add tests for verify, overwrite, and no-verify modes (@mmalenic)
+- Add verify flag, use "-" instead of "--stdin", add version and remove name from output file, overwrite when merging (@mmalenic)
+- Use kebab-case because that's what checksum names will be based on (@mmalenic)
+- Add ability to append to existing checksums file and option to force overwrite (@mmalenic)
+- Rework input to use position arg as default and pass --stdin for stdin (@mmalenic)
+- Add output file and write checksums instead of printing (@mmalenic)
+- Add single-part aws-etag CLI parsing and calculation (@mmalenic)
+- Add definition for output file (@mmalenic)
+- Add -le and -be extension to enum variants on CLI (@mmalenic)
+- Add crc32c checksum (@mmalenic)
+- Add crc32 checksum (@mmalenic)
+- Generate test file with mutex guard so tests can run in parallel (@mmalenic)
+- Add test action (@mmalenic)
+- Use multiple mpsc channels to fix slow receiver (@mmalenic)
+- Add some unit tests and update test file generator (@mmalenic)
+- Add test file generating module (@mmalenic)
+- Add chunk size configuration to reader (@mmalenic)
+- Use async_channel, as it seems to perform better and have a simpler unbounded implementation (@mmalenic)
+- Refine benchmarks and avoid lagging receiver (@mmalenic)
+- Add benchmarks for channel reader (@mmalenic)
+- Create task executor, confine channels to channel reader, and perform checksum task in checksum enum (@mmalenic)
+- Add reader structs and refine task types (@mmalenic)
+- Refine check command arguments (@mmalenic)
+- Add some subcommands and rename package (@mmalenic)
+- Add explaining comments (@mmalenic)
+- Add basic outline of concurrent checksums (@mmalenic)
+- Add basic skeleton with argument parsing (@mmalenic)
+- Initial commit (@andrewpatto)
+
+

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask"
+publish = false
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+git-cliff = { version = "2.13", default-features = false, features = ["github"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -98,7 +98,8 @@ fn run_cliff(root: &Path, config_path: &Path, tag: &str) -> Result<String> {
     let mut buf = Vec::new();
     git_cliff::write_changelog(&opt, changelog, &mut buf).context("rendering changelog")?;
 
-    String::from_utf8(buf).context("changelog output not UTF-8")
+    let rendered = String::from_utf8(buf).context("changelog output not UTF-8")?;
+    Ok(format!("{}\n", rendered.trim_end()))
 }
 
 /// Replace everything from the spec's `%changelog` line onwards with `entries`.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,121 @@
+//! Workspace automation tasks.
+//!
+//! Run with `cargo xtask <command>`.
+//!
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+use anyhow::{Context, Result, bail};
+use clap::{Parser, Subcommand};
+use git_cliff::args::Opt;
+
+#[derive(Parser)]
+#[command(name = "xtask", about = "Workspace automation tasks")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Regenerate the Debian and RPM packaging changelogs from git history.
+    Changelog,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Changelog => changelog(),
+    }
+}
+
+/// Absolute path to the workspace root.
+fn repo_root() -> PathBuf {
+    if let Some(root) = env::var_os("XTASK_ROOT") {
+        return PathBuf::from(root);
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask crate should have a parent directory")
+        .to_path_buf()
+}
+
+/// Regenerate the Debian and RPM packaging changelogs with git-cliff.
+fn changelog() -> Result<()> {
+    let root = repo_root();
+    let version = crate_version(&root.join("copyrite/Cargo.toml"))?;
+    let tag = format!("v{version}");
+
+    let debian = run_cliff(&root, &root.join("pkg/cliff-debian.toml"), &tag)?;
+    fs::write(root.join("pkg/debian/changelog"), &debian)
+        .context("writing pkg/debian/changelog")?;
+
+    let rpm_entries = run_cliff(&root, &root.join("pkg/cliff-rpm.toml"), &tag)?;
+    append_rpm_changelog(&root.join("pkg/rpm/copyrite.spec"), &rpm_entries)?;
+
+    Ok(())
+}
+
+/// Read the crate version from `copyrite/Cargo.toml`.
+fn crate_version(manifest: &Path) -> Result<String> {
+    let text =
+        fs::read_to_string(manifest).with_context(|| format!("reading {}", manifest.display()))?;
+    for line in text.lines() {
+        // Match a literal `version = "x.y.z"`, not `rust-version` or `version.workspace`.
+        let Some(rest) = line.trim().strip_prefix("version") else {
+            continue;
+        };
+        let Some(value) = rest.trim_start().strip_prefix('=') else {
+            continue;
+        };
+        let version = value.trim().trim_matches('"');
+        if !version.is_empty() {
+            return Ok(version.to_string());
+        }
+    }
+
+    bail!("could not find a version in {}", manifest.display())
+}
+
+/// Render a changelog with git-cliff, tagging the unreleased commits as `tag`.
+fn run_cliff(root: &Path, config_path: &Path, tag: &str) -> Result<String> {
+    let opt = Opt::parse_from([
+        OsStr::new("git-cliff"),
+        OsStr::new("--config"),
+        config_path.as_os_str(),
+        OsStr::new("--repository"),
+        root.as_os_str(),
+        OsStr::new("--tag"),
+        OsStr::new(tag),
+    ]);
+
+    let changelog = git_cliff::run(opt.clone())
+        .with_context(|| format!("running git-cliff with {}", config_path.display()))?;
+
+    let mut buf = Vec::new();
+    git_cliff::write_changelog(&opt, changelog, &mut buf).context("rendering changelog")?;
+
+    String::from_utf8(buf).context("changelog output not UTF-8")
+}
+
+/// Replace everything from the spec's `%changelog` line onwards with `entries`.
+fn append_rpm_changelog(spec_path: &Path, entries: &str) -> Result<()> {
+    let spec = fs::read_to_string(spec_path)
+        .with_context(|| format!("reading {}", spec_path.display()))?;
+
+    const MARKER: &str = "%changelog\n";
+    let marker_end = spec
+        .find(MARKER)
+        .map(|i| i + MARKER.len())
+        .context("could not find '%changelog' section in pkg/rpm/copyrite.spec")?;
+
+    let mut out = String::with_capacity(marker_end + entries.len());
+    out.push_str(&spec[..marker_end]);
+    out.push_str(entries);
+
+    fs::write(spec_path, &out).with_context(|| format!("writing {}", spec_path.display()))?;
+    Ok(())
+}


### PR DESCRIPTION
Closes #83

I think this is now the correct approach, and it automates creating the debian/rpm packages. This works by using an xtask inside the repo: https://github.com/matklad/cargo-xtask, which calls gif-cliff. The release-plz automation also uses git-cliff, so now the changelogs should be consistent, rather than manually published.

### Changes
* Add git-cliff automation for debian/rpm changelogs using an xtask crate.
* Automatically adjust and release a debian/rpm package when release-plz creates it's own release PR.

I wonder if we could ever get this inside the real debian/rpm repositories. 