### PR TITLE
fix: copy when source == destination

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -10,7 +10,7 @@ use crate::io::sums::ObjectSumsBuilder;
 use crate::io::sums::channel::ChannelReader;
 use crate::io::{CredentialOverrides, Provider};
 use crate::stats;
-use crate::stats::{CheckStats, ChecksumPair, CopyStats, GenerateStats};
+use crate::stats::{CheckStats, CopyStats, CopySuccessReason, GenerateStats};
 use crate::task::ClientInput;
 use crate::task::check::{CheckTask, CheckTaskBuilder, GroupBy};
 use crate::task::copy::CopyTaskBuilder;
@@ -746,7 +746,7 @@ impl Copy {
                 destination: self.destination,
                 bytes_transferred: 0,
                 copy_mode: self.copy_mode,
-                reason: None,
+                success_reason: None,
                 skipped: false,
                 sums_mismatch: false,
                 n_retries: 0,
@@ -774,7 +774,9 @@ impl Copy {
                 destination: self.destination,
                 bytes_transferred: 0,
                 copy_mode: self.copy_mode,
-                reason: None,
+                success_reason: Some(CopySuccessReason::message(
+                    "source and destination are the same object",
+                )),
                 skipped: true,
                 sums_mismatch: false,
                 n_retries: 0,
@@ -827,14 +829,18 @@ impl Copy {
                     })?;
 
                 if check_stats.groups.len() == 1 {
-                    let reason = Option::<ChecksumPair>::from(&check_stats);
+                    let reason = Option::<CopySuccessReason>::from(&check_stats).or_else(|| {
+                        Some(CopySuccessReason::message(
+                            "destination already matches source",
+                        ))
+                    });
                     let copy_stats = CopyStats {
                         elapsed_seconds: 0.0,
                         source: self.source,
                         destination: self.destination,
                         bytes_transferred: 0,
                         copy_mode: self.copy_mode,
-                        reason: reason.clone(),
+                        success_reason: reason.clone(),
                         skipped: true,
                         sums_mismatch: false,
                         n_retries: 0,
@@ -845,11 +851,13 @@ impl Copy {
 
                     let elapsed = now.elapsed();
                     if ui {
-                        if let Some(reason) = reason {
+                        if let Some(reason) = reason
+                            && let Some(checksum_match) = reason.checksum_match
+                        {
                             println!(
                                 "  {} {} sums match, skipping copy!",
                                 style("·").bold(),
-                                style(reason.kind).green()
+                                style(checksum_match.kind).green()
                             );
                         }
                         println!("Done in {}", HumanDuration(elapsed));
@@ -923,17 +931,28 @@ impl Copy {
                     .with_elapsed(now.elapsed())
                 })?;
 
-            if ui && let Some(reason) = Option::<ChecksumPair>::from(&check_stats) {
+            let reason = Option::<CopySuccessReason>::from(&check_stats)
+                .or_else(|| Some(CopySuccessReason::message("copy verified")));
+
+            if ui
+                && let Some(reason) = &reason
+                && let Some(checksum_match) = &reason.checksum_match
+            {
                 println!(
                     "  {} {} sums match!",
                     style("·").bold(),
-                    style(reason.kind).green()
+                    style(checksum_match.kind.clone()).green()
                 );
             }
 
-            CopyStats::from_task(result, Some(check_stats), false, mismatch)
+            CopyStats::from_task(result, Some(check_stats), false, mismatch, reason)
         } else {
-            CopyStats::from_task(result, None, false, mismatch)
+            let reason = CopySuccessReason::message("copied without checksum verification");
+            if ui {
+                println!("  {} {}", style("·").bold(), reason.message);
+            }
+
+            CopyStats::from_task(result, None, false, mismatch, Some(reason))
         };
 
         let elapsed = now.elapsed();

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -3,7 +3,7 @@
 
 use crate::checksum::Ctx;
 use crate::error::Error;
-use crate::error::Error::{CheckError, GenerateError, ParseError};
+use crate::error::Error::{CheckError, CopyError, GenerateError, ParseError};
 use crate::error::Result;
 use crate::io::S3Client;
 use crate::io::sums::ObjectSumsBuilder;
@@ -728,6 +728,63 @@ impl Copy {
         ui: bool,
     ) -> stats::Result<CopyStats> {
         let now = Instant::now();
+
+        // Verify the source exists before continuing.
+        let source_exists = ObjectSumsBuilder::default()
+            .set_client(Some(source_client.clone()))
+            .build(self.source.to_string())
+            .await?
+            .file_size()
+            .await
+            .is_ok_and(|size| size.is_some());
+
+        if !source_exists {
+            let err_msg = format!("source does not exist: {}", self.source);
+            return Err(Box::new(CopyStats {
+                elapsed_seconds: 0.0,
+                source: self.source,
+                destination: self.destination,
+                bytes_transferred: 0,
+                copy_mode: self.copy_mode,
+                reason: None,
+                skipped: false,
+                sums_mismatch: false,
+                n_retries: 0,
+                api_errors: HashSet::new(),
+                check_stats: None,
+                unrecoverable_error: Some(CopyError(err_msg)),
+            }));
+        }
+
+        // If source and destination refer to the same object, treat as a no-op.
+        if Provider::try_from(self.source.as_str())?
+            .is_same_location(&Provider::try_from(self.destination.as_str())?)
+        {
+            if ui {
+                println!(
+                    "{} source and destination are the same ({}), nothing to copy",
+                    style("warning:").yellow().bold(),
+                    self.source
+                );
+            }
+
+            let copy_stats = CopyStats {
+                elapsed_seconds: 0.0,
+                source: self.source,
+                destination: self.destination,
+                bytes_transferred: 0,
+                copy_mode: self.copy_mode,
+                reason: None,
+                skipped: true,
+                sums_mismatch: false,
+                n_retries: 0,
+                api_errors: HashSet::new(),
+                check_stats: None,
+                unrecoverable_error: None,
+            };
+
+            return Ok(copy_stats.with_elapsed(now.elapsed()));
+        }
 
         let mut exists = false;
         if !self.no_skip {

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -362,13 +362,10 @@ impl Provider {
 
     /// Check whether two providers refer to the same object.
     pub fn is_same_location(&self, other: &Provider) -> bool {
-        if self == other {
-            return true;
-        }
-
-        // S3 matching is handled by the equality comparison above. This canonicalizes the path
-        // in order to check files too.
         match (self, other) {
+            (source @ Provider::S3 { .. }, destination @ Provider::S3 { .. }) => {
+                source == destination
+            }
             (Provider::File { file: self_file }, Provider::File { file: other_file }) => {
                 let self_path = Path::new(self_file.as_str());
                 let other_path = Path::new(other_file.as_str());

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -14,6 +14,7 @@ use aws_sdk_s3::{Client, config};
 use aws_smithy_runtime_api::client::behavior_version::BehaviorVersion;
 use pastey::paste;
 use serde::Deserialize;
+use std::path::Path;
 use std::result;
 use std::sync::Arc;
 
@@ -277,7 +278,7 @@ impl S3Client {
 }
 
 /// The type of provider for the object.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Provider {
     File { file: String },
     S3 { bucket: String, key: String },
@@ -357,6 +358,28 @@ impl Provider {
     /// Check if the provider is an S3 provider.
     pub fn is_s3(&self) -> bool {
         matches!(self, Provider::S3 { .. })
+    }
+
+    /// Check whether two providers refer to the same object.
+    pub fn is_same_location(&self, other: &Provider) -> bool {
+        if self == other {
+            return true;
+        }
+
+        // S3 matching is handled by the equality comparison above. This canonicalizes the path
+        // in order to check files too.
+        match (self, other) {
+            (Provider::File { file: self_file }, Provider::File { file: other_file }) => {
+                let self_path = Path::new(self_file.as_str());
+                let other_path = Path::new(other_file.as_str());
+
+                match (self_path.canonicalize(), other_path.canonicalize()) {
+                    (Ok(canonical_self), Ok(canonical_other)) => canonical_self == canonical_other,
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
     }
 }
 
@@ -520,7 +543,9 @@ mod tests {
     use anyhow::Result;
     use aws_credential_types::Credentials;
     use serde_json::json;
+    use std::env;
     use std::time::{Duration, SystemTime};
+    use tempfile::{NamedTempFile, tempdir};
 
     #[tokio::test]
     pub async fn test_parse_url() -> Result<()> {
@@ -666,5 +691,64 @@ mod tests {
             )
             .provider_name("test")
             .build()
+    }
+
+    #[test]
+    fn is_same_location() {
+        let source = Provider::try_from("s3://bucket/key").unwrap();
+        let destination = Provider::try_from("s3://bucket/key").unwrap();
+        assert!(source.is_same_location(&destination));
+
+        let source = Provider::try_from("s3://bucket/key1").unwrap();
+        let destination = Provider::try_from("s3://bucket/key2").unwrap();
+        assert!(!source.is_same_location(&destination));
+
+        let source = Provider::try_from("s3://bucket1/key").unwrap();
+        let destination = Provider::try_from("s3://bucket2/key").unwrap();
+        assert!(!source.is_same_location(&destination));
+
+        let source = Provider::try_from("s3://bucket/key").unwrap();
+        let destination = Provider::try_from("s3://bucket/key/").unwrap();
+        assert!(!source.is_same_location(&destination));
+
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_string_lossy().to_string();
+
+        let source = Provider::try_from(path.as_str()).unwrap();
+        let destination = Provider::try_from(path.as_str()).unwrap();
+        assert!(source.is_same_location(&destination));
+
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_string_lossy().to_string();
+        let prefixed = format!("file://{}", path);
+
+        let source = Provider::try_from(path.as_str()).unwrap();
+        let destination = Provider::try_from(prefixed.as_str()).unwrap();
+        assert!(source.is_same_location(&destination));
+
+        let file = NamedTempFile::new_in(env::current_dir().unwrap()).unwrap();
+        let abs_path = file.path().to_string_lossy().to_string();
+        let rel_path = format!("./{}", file.path().file_name().unwrap().to_string_lossy());
+
+        let source = Provider::try_from(abs_path.as_str()).unwrap();
+        let destination = Provider::try_from(rel_path.as_str()).unwrap();
+        assert!(source.is_same_location(&destination));
+
+        let dir = tempdir().unwrap();
+        let original = dir.path().join("original");
+        std::fs::write(&original, "data").unwrap();
+
+        let file1 = NamedTempFile::new().unwrap();
+        let file2 = NamedTempFile::new().unwrap();
+        let path1 = file1.path().to_string_lossy().to_string();
+        let path2 = file2.path().to_string_lossy().to_string();
+
+        let source = Provider::try_from(path1.as_str()).unwrap();
+        let destination = Provider::try_from(path2.as_str()).unwrap();
+        assert!(!source.is_same_location(&destination));
+
+        let source = Provider::try_from("s3://bucket/key").unwrap();
+        let destination = Provider::try_from("/tmp/file").unwrap();
+        assert!(!source.is_same_location(&destination));
     }
 }

--- a/copyrite/src/stats.rs
+++ b/copyrite/src/stats.rs
@@ -146,6 +146,40 @@ impl From<&CheckStats> for Option<ChecksumPair> {
     }
 }
 
+/// The reason a copy was considered successful or was skipped.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CopySuccessReason {
+    /// The matching checksum that determined the copy was correct, if a checksum comparison
+    /// was performed. This is absent when the copy was skipped for a reason unrelated to
+    /// checksums, such as the source and destination being the same object.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) checksum_match: Option<ChecksumPair>,
+    /// A message describing why the copy succeeded or was skipped.
+    pub(crate) message: String,
+}
+
+impl CopySuccessReason {
+    /// Create a new copy reason.
+    pub fn new(checksum_match: Option<ChecksumPair>, message: impl Into<String>) -> Self {
+        Self {
+            checksum_match,
+            message: message.into(),
+        }
+    }
+
+    /// Create a copy reason with only a message and no checksum match.
+    pub fn message(message: impl Into<String>) -> Self {
+        Self::new(None, message)
+    }
+}
+
+impl From<&CheckStats> for Option<CopySuccessReason> {
+    fn from(stats: &CheckStats) -> Self {
+        Option::<ChecksumPair>::from(stats)
+            .map(|checksum_match| CopySuccessReason::new(Some(checksum_match), "checksums match"))
+    }
+}
+
 /// A list of checksum pair "reasons".
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ChecksumStats(Vec<ChecksumPair>);
@@ -313,11 +347,13 @@ pub struct CopyStats {
     pub(crate) sums_mismatch: bool,
     /// The mode of the copy, either server-side or download-upload.
     pub(crate) copy_mode: CopyMode,
-    /// The reason a copy was considered successful. This shows the matching checksum that
-    /// determines that the copy completed correctly. If the copy was skipped, this shows the
-    /// matching checksum.
+    /// The reason a copy was considered successful or was skipped.
+    ///
+    /// For checksum-verified copies this contains the matching checksum. For copies skipped
+    /// for other reasons, such as the source and destination being the same object, only the
+    /// message is populated.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) reason: Option<ChecksumPair>,
+    pub(crate) success_reason: Option<CopySuccessReason>,
     /// The number of retries if there was permission issues for copying metadata or tags.
     pub(crate) n_retries: u64,
     /// Stats from checking sums to ensure that the copy was successful.
@@ -342,7 +378,7 @@ impl From<Error> for Box<CopyStats> {
 
 impl From<CopyTaskError> for Box<CopyStats> {
     fn from(err: CopyTaskError) -> Self {
-        let mut stats = CopyStats::from_task(err.task, None, false, false);
+        let mut stats = CopyStats::from_task(err.task, None, false, false, None);
         stats.unrecoverable_error = Some(err.error);
         Box::new(stats)
     }
@@ -366,7 +402,7 @@ impl CopyStats {
             skipped,
             sums_mismatch,
             copy_mode,
-            reason: Option::<ChecksumPair>::from(&check_stats),
+            success_reason: Option::<CopySuccessReason>::from(&check_stats),
             n_retries: 0,
             api_errors: Default::default(),
             check_stats: Some(check_stats),
@@ -380,6 +416,7 @@ impl CopyStats {
         check_stats: Option<CheckStats>,
         skipped: bool,
         sums_mismatch: bool,
+        reason: Option<CopySuccessReason>,
     ) -> Self {
         Self {
             elapsed_seconds: 0.0,
@@ -389,7 +426,7 @@ impl CopyStats {
             skipped,
             sums_mismatch,
             copy_mode: copy_task.copy_mode(),
-            reason: check_stats.as_ref().and_then(Option::<ChecksumPair>::from),
+            success_reason: reason,
             n_retries: copy_task.n_retries(),
             api_errors: copy_task.api_errors(),
             check_stats,


### PR DESCRIPTION
Closes #100 

### Changes
* Allow copies when `source == destination`, including canonicalizing a filesystem path.

Also follow up from #103, adding in the alias which I forgot from that PR.