### PR TITLE
fix: release plz config related to workspace packages

### DIFF
--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
       found: ${{ steps.release.outputs.found }}
     steps:
       - name: Get latest release tag
@@ -24,7 +25,10 @@ jobs:
           if [ -z "$TAG" ]; then
             echo "found=false" >> $GITHUB_OUTPUT
           else
+            version="${TAG#copyrite-}"
+            version="${version#v}"
             echo "tag=$TAG" >> $GITHUB_OUTPUT
+            echo "version=$version" >> $GITHUB_OUTPUT
             echo "found=true" >> $GITHUB_OUTPUT
           fi
   release-binary-assets:
@@ -54,6 +58,7 @@ jobs:
         with:
           bin: copyrite
           target: ${{ matrix.target }}
+          archive: $bin-${{ needs.get-release.outputs.version }}-$target
           ref: refs/tags/${{ needs.get-release.outputs.tag }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,6 +67,8 @@ jobs:
     if: ${{ needs.get-release.outputs.found == 'true' }}
     permissions:
       contents: write
+    env:
+      PKG_VERSION: ${{ needs.get-release.outputs.version }}
     strategy:
       matrix:
         include:
@@ -75,10 +82,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.get-release.outputs.tag }}
-      - name: Get package version from release tag
-        run: |
-          version="${{ needs.get-release.outputs.tag }}"
-          echo "PKG_VERSION=${version#v}" >> "$GITHUB_ENV"
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y rpm debhelper build-essential devscripts
       - name: Install Rust

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,7 @@
+[[package]]
+name = "xtask"
+release = false
+
+[[package]]
+name = "copyrite"
+git_tag_name = "v{{ version }}"


### PR DESCRIPTION
Related to #103 

Adding xtask caused release-plz to use a different mode for publishing, which broke the version extraction in the CI workflow. This fixes that, and also adds the version to published binaries.