### PR TITLE
fix: naming of git release

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,3 +6,4 @@ publish = false
 [[package]]
 name = "copyrite"
 git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"


### PR DESCRIPTION
Related to #101, fixes naming of github release.