### PR TITLE
feat: streams and checksums

### DIFF
--- a/copyrite/src/checksum/file.rs
+++ b/copyrite/src/checksum/file.rs
@@ -253,6 +253,11 @@ impl Checksum {
     pub fn new(checksum: String) -> Self {
         Self(checksum)
     }
+
+    /// Get the inner checksum value.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
 }
 
 #[cfg(test)]

--- a/copyrite/src/checksum/mod.rs
+++ b/copyrite/src/checksum/mod.rs
@@ -126,16 +126,19 @@ impl Ctx {
     pub fn is_preferred_single_part(&self, provider: &Provider) -> bool {
         matches!(self, Self::Regular(regular) if regular.is_preferred_cloud_ctx(provider))
     }
+
+    /// Get the underlying standard checksum context.
+    pub fn into_standard(self) -> StandardCtx {
+        match self {
+            Ctx::AWSEtag(ctx) => ctx.ctx(),
+            Ctx::Regular(ctx) => ctx,
+        }
+    }
 }
 
 impl From<Ctx> for ChecksumAlgorithm {
     fn from(ctx: Ctx) -> Self {
-        let ctx = match ctx {
-            Ctx::AWSEtag(ctx) => ctx.ctx(),
-            Ctx::Regular(ctx) => ctx,
-        };
-
-        match ctx {
+        match ctx.into_standard() {
             StandardCtx::CRC64NVME(_, _) => ChecksumAlgorithm::Crc64Nvme,
             StandardCtx::CRC32C(_, _) => ChecksumAlgorithm::Crc32C,
             StandardCtx::CRC32(_, _) => ChecksumAlgorithm::Crc32,

--- a/copyrite/src/checksum/standard.rs
+++ b/copyrite/src/checksum/standard.rs
@@ -357,9 +357,23 @@ impl StandardCtx {
         !matches!(self, StandardCtx::QuickXor)
     }
 
-    /// Is this an AWS additional checksum that can be specified.
+    /// Is this an AWS additional checksum that can be specified. S3 supports all algorithms
+    /// except QuickXor, including MD5 via the `x-amz-checksum-md5` header.
     pub fn is_aws_additional_ctx(&self) -> bool {
-        !matches!(self, StandardCtx::QuickXor | StandardCtx::MD5(_))
+        !matches!(self, StandardCtx::QuickXor)
+    }
+
+    /// Can the SDK automatically compute this checksum when uploading. S3 accepts MD5, SHA512
+    /// and the XXHash family only as precalculated values.
+    pub fn is_sdk_computable_ctx(&self) -> bool {
+        matches!(
+            self,
+            StandardCtx::CRC64NVME(_, _)
+                | StandardCtx::CRC32C(_, _)
+                | StandardCtx::CRC32(_, _)
+                | StandardCtx::SHA1(_)
+                | StandardCtx::SHA256(_)
+        )
     }
 }
 

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -536,8 +536,9 @@ impl MetadataCopy {
 /// Mode to execute copy task in.
 #[derive(Debug, Clone, ValueEnum, Copy, Default, Deserialize, Serialize)]
 pub enum CopyMode {
-    /// Always use server-side copy operations if they are available. This may still download and
-    /// upload if it is not possible to server-side copy.
+    /// Use server-side copy operations if they are available. This falls back to download-upload
+    /// when the destination cannot directly read the source object, e.g. when copying between
+    /// different endpoints or with credentials that cannot access the source.
     #[default]
     ServerSide,
     /// Download the object first and then upload it to the destination.
@@ -596,7 +597,7 @@ impl StalledStreamProtection {
 }
 
 /// Details of how to locate credentials or specify no credentials needed
-#[derive(Debug, Clone, ValueEnum, Copy, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, ValueEnum, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub enum CredentialProvider {
     /// Use the default mechanism of the SDK that obtains credentials from the system
     #[default]
@@ -717,6 +718,31 @@ impl Copy {
         Ok(result)
     }
 
+    /// Determine whether a server-side copy is possible by fetching the source object's ETag with
+    /// both clients.
+    async fn server_side_allowed(
+        source: &Provider,
+        source_client: &S3Client,
+        destination_client: &S3Client,
+    ) -> bool {
+        let Provider::S3 { bucket, key } = source else {
+            return false;
+        };
+
+        let source_etag = source_client
+            .head_object(|builder| builder.bucket(bucket.as_str()).key(key.as_str()))
+            .await
+            .ok()
+            .and_then(|head| head.e_tag);
+        let destination_etag = destination_client
+            .head_object(|builder| builder.bucket(bucket.as_str()).key(key.as_str()))
+            .await
+            .ok()
+            .and_then(|head| head.e_tag);
+
+        source_etag.is_some() && source_etag == destination_etag
+    }
+
     /// Perform the copy sub command from the args.
     pub async fn copy(
         self,
@@ -728,6 +754,24 @@ impl Copy {
         ui: bool,
     ) -> stats::Result<CopyStats> {
         let now = Instant::now();
+
+        let source_provider = Provider::try_from(self.source.as_str())?;
+        let destination_provider = Provider::try_from(self.destination.as_str())?;
+
+        // Server-side copies require the destination client to read the source object directly.
+        // The same configuration guarantees this, otherwise probe the source object with both
+        // clients to determine whether the destination sees the same object as the source.
+        let copy_mode = if self.copy_mode.is_download_upload()
+            || credentials.is_same_configuration()
+            || !source_provider.is_s3()
+            || !destination_provider.is_s3()
+            || Self::server_side_allowed(&source_provider, &source_client, &destination_client)
+                .await
+        {
+            self.copy_mode
+        } else {
+            CopyMode::DownloadUpload
+        };
 
         // Verify the source exists before continuing.
         let source_exists = ObjectSumsBuilder::default()
@@ -745,7 +789,7 @@ impl Copy {
                 source: self.source,
                 destination: self.destination,
                 bytes_transferred: 0,
-                copy_mode: self.copy_mode,
+                copy_mode,
                 success_reason: None,
                 skipped: false,
                 sums_mismatch: false,
@@ -757,9 +801,7 @@ impl Copy {
         }
 
         // If source and destination refer to the same object, treat as a no-op.
-        if Provider::try_from(self.source.as_str())?
-            .is_same_location(&Provider::try_from(self.destination.as_str())?)
-        {
+        if source_provider.is_same_location(&destination_provider) {
             if ui {
                 println!(
                     "{} source and destination are the same ({}), nothing to copy",
@@ -773,7 +815,7 @@ impl Copy {
                 source: self.source,
                 destination: self.destination,
                 bytes_transferred: 0,
-                copy_mode: self.copy_mode,
+                copy_mode,
                 success_reason: Some(CopySuccessReason::message(
                     "source and destination are the same object",
                 )),
@@ -820,7 +862,7 @@ impl Copy {
                         CopyStats::from_check_stats(
                             self.source.to_string(),
                             self.destination.to_string(),
-                            self.copy_mode,
+                            copy_mode,
                             *err,
                             false,
                             false,
@@ -839,7 +881,7 @@ impl Copy {
                         source: self.source,
                         destination: self.destination,
                         bytes_transferred: 0,
-                        copy_mode: self.copy_mode,
+                        copy_mode,
                         success_reason: reason.clone(),
                         skipped: true,
                         sums_mismatch: false,
@@ -879,12 +921,13 @@ impl Copy {
             }
         }
 
-        // The copy mode must be download-upload if not using default credential providers.
-        let copy_mode = if credentials.is_default() {
-            self.copy_mode
-        } else {
-            CopyMode::DownloadUpload
-        };
+        if ui && self.copy_mode.is_server_side() && copy_mode.is_download_upload() {
+            println!(
+                "{} destination cannot read the source directly, copying using {}",
+                style("note:").cyan().bold(),
+                style(CopyMode::DownloadUpload).green(),
+            );
+        }
 
         let result = CopyTaskBuilder::default()
             .with_source(self.source.to_string())
@@ -923,7 +966,7 @@ impl Copy {
                     CopyStats::from_check_stats(
                         self.source.to_string(),
                         self.destination.to_string(),
-                        self.copy_mode,
+                        copy_mode,
                         *err,
                         false,
                         false,
@@ -1660,16 +1703,16 @@ impl Credentials {
         S3Client::new_from_cli_destination(self, compatibility).await
     }
 
-    /// Check if the default credentials are being used without any overrides.
-    pub fn is_default(&self) -> bool {
-        self.effective_source_credential_provider().is_default()
-            && self
-                .effective_destination_credential_provider()
-                .is_default()
-            && self.effective_source_endpoint_url().is_none()
-            && self.effective_destination_endpoint_url().is_none()
-            && !self.source_overrides().any()
-            && !self.destination_overrides().any()
+    /// Whether the source and destination resolve to the same effective configuration.
+    /// When true, a server-side copy issued on the destination client reads the same
+    /// object the source client has.
+    pub fn is_same_configuration(&self) -> bool {
+        self.effective_source_credential_provider()
+            == self.effective_destination_credential_provider()
+            && self.effective_source_profile() == self.effective_destination_profile()
+            && self.effective_source_secret() == self.effective_destination_secret()
+            && self.effective_source_endpoint_url() == self.effective_destination_endpoint_url()
+            && self.source_overrides() == self.destination_overrides()
     }
 
     /// Check if any source or destination options are set.
@@ -1718,5 +1761,177 @@ impl Credentials {
                 .clone()
                 .or(self.session_token.clone()),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_s3::Client;
+    use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
+    use aws_smithy_mocks::{MockResponseInterceptor, Rule, RuleMode, mock};
+    use aws_smithy_types::error::ErrorMetadata;
+    use std::sync::Arc;
+
+    fn mock_s3_client(rule: Rule) -> S3Client {
+        let interceptor = MockResponseInterceptor::new()
+            .rule_mode(RuleMode::MatchAny)
+            .with_rule(&rule);
+        S3Client::new(
+            Arc::new(Client::from_conf(
+                aws_sdk_s3::config::Config::builder()
+                    .with_test_defaults_v2()
+                    .http_client(aws_smithy_mocks::create_mock_http_client())
+                    .interceptor(interceptor)
+                    .build(),
+            )),
+            false,
+            false,
+        )
+    }
+
+    fn head_etag_client(etag: &str) -> S3Client {
+        let etag = etag.to_string();
+        mock_s3_client(
+            mock!(Client::head_object)
+                .match_requests(|req| req.bucket() == Some("bucket") && req.key() == Some("key"))
+                .then_output(move || HeadObjectOutput::builder().e_tag(etag.as_str()).build()),
+        )
+    }
+
+    fn head_error_client() -> S3Client {
+        mock_s3_client(mock!(Client::head_object).then_error(|| {
+            HeadObjectError::generic(ErrorMetadata::builder().code("AccessDenied").build())
+        }))
+    }
+
+    fn source_provider() -> Provider {
+        Provider::parse_s3_url("s3://bucket/key").unwrap()
+    }
+
+    fn credentials(args: &[&str]) -> Credentials {
+        let command = [
+            "copyrite",
+            "copy",
+            "s3://source/key",
+            "s3://destination/key",
+        ]
+        .into_iter()
+        .chain(args.iter().copied());
+        Command::parse_from_iter(command).unwrap().credentials
+    }
+
+    #[tokio::test]
+    async fn server_side_allowed_matching_etags() {
+        assert!(
+            Copy::server_side_allowed(
+                &source_provider(),
+                &head_etag_client("etag"),
+                &head_etag_client("etag"),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn server_side_not_allowed_different_etags() {
+        assert!(
+            !Copy::server_side_allowed(
+                &source_provider(),
+                &head_etag_client("etag"),
+                &head_etag_client("different-etag"),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn server_side_not_allowed_destination_error() {
+        assert!(
+            !Copy::server_side_allowed(
+                &source_provider(),
+                &head_etag_client("etag"),
+                &head_error_client(),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn server_side_not_allowed_source_error() {
+        assert!(
+            !Copy::server_side_allowed(
+                &source_provider(),
+                &head_error_client(),
+                &head_etag_client("etag"),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn server_side_not_allowed_file_source() {
+        assert!(
+            !Copy::server_side_allowed(
+                &Provider::parse_file_url("file"),
+                &head_etag_client("etag"),
+                &head_etag_client("etag"),
+            )
+            .await
+        );
+    }
+
+    #[test]
+    fn same_configuration_defaults() {
+        assert!(credentials(&[]).is_same_configuration());
+    }
+
+    #[test]
+    fn same_configuration_shared_options() {
+        assert!(credentials(&["--endpoint-url", "http://localhost:8000"]).is_same_configuration());
+        assert!(
+            credentials(&["--credential-provider", "aws-profile", "--profile", "name"])
+                .is_same_configuration()
+        );
+        assert!(
+            credentials(&["--access-key-id", "id", "--secret-access-key", "key"])
+                .is_same_configuration()
+        );
+    }
+
+    #[test]
+    fn same_configuration_equal_prefixed_options() {
+        assert!(
+            credentials(&[
+                "--source-endpoint-url",
+                "http://localhost:8000",
+                "--destination-endpoint-url",
+                "http://localhost:8000",
+            ])
+            .is_same_configuration()
+        );
+    }
+
+    #[test]
+    fn different_configuration_prefixed_options() {
+        assert!(
+            !credentials(&["--source-endpoint-url", "http://localhost:8000"])
+                .is_same_configuration()
+        );
+        assert!(
+            !credentials(&["--destination-credential-provider", "no-credentials"])
+                .is_same_configuration()
+        );
+        assert!(!credentials(&["--source-profile", "name"]).is_same_configuration());
+        assert!(!credentials(&["--source-access-key-id", "id"]).is_same_configuration());
+        assert!(
+            !credentials(&[
+                "--endpoint-url",
+                "http://localhost:8000",
+                "--destination-endpoint-url",
+                "http://localhost:9000",
+            ])
+            .is_same_configuration()
+        );
     }
 }

--- a/copyrite/src/cli.rs
+++ b/copyrite/src/cli.rs
@@ -1104,7 +1104,8 @@ pub struct Compatibility {
     /// Enable all compatibility options.
     ///
     /// This is a convenience flag that enables `--force-path-style`,
-    /// `--no-get-object-attributes`, `--no-checksum-mode`, and `--no-request-checksum`.
+    /// `--no-get-object-attributes`, `--no-checksum-mode`, `--no-request-checksum`, and
+    /// `--no-precalculated-checksum`.
     ///
     /// For the copy command, each compatibility option can also be prefixed with
     /// `source-` or `destination-` to enable additional compatibility per-side (e.g.
@@ -1168,6 +1169,19 @@ pub struct Compatibility {
         hide_short_help = true
     )]
     pub no_request_checksum: bool,
+    /// Do not send precalculated checksum values on uploads.
+    ///
+    /// Additional checksums that the SDK cannot compute during an upload are normally sent
+    /// as precalculated values from the sums file. Some S3-compatible endpoints do not support
+    /// this. This option skips the precalculated values so that uploads succeed without them.
+    /// Checksums that the SDK computes during the upload are unaffected.
+    #[arg(
+        global = true,
+        long,
+        env = "COPYRITE_NO_PRECALCULATED_CHECKSUM",
+        hide_short_help = true
+    )]
+    pub no_precalculated_checksum: bool,
     /// Controls overriding the AWS SDK's stalled stream protection.
     ///
     /// SSP is useful to prevent dead TCP connections from hanging if the SDK detects that no bytes are
@@ -1220,6 +1234,13 @@ pub struct Compatibility {
     #[arg(
         global = true,
         long,
+        env = "COPYRITE_SOURCE_NO_PRECALCULATED_CHECKSUM",
+        hide = true
+    )]
+    pub source_no_precalculated_checksum: bool,
+    #[arg(
+        global = true,
+        long,
         env = "COPYRITE_SOURCE_STALLED_STREAM_PROTECTION",
         hide = true
     )]
@@ -1262,6 +1283,13 @@ pub struct Compatibility {
     #[arg(
         global = true,
         long,
+        env = "COPYRITE_DESTINATION_NO_PRECALCULATED_CHECKSUM",
+        hide = true
+    )]
+    pub destination_no_precalculated_checksum: bool,
+    #[arg(
+        global = true,
+        long,
         env = "COPYRITE_DESTINATION_STALLED_STREAM_PROTECTION",
         hide = true
     )]
@@ -1287,6 +1315,11 @@ impl Compatibility {
     /// Whether to disable automatic request checksum calculation.
     pub fn no_request_checksum(&self) -> bool {
         self.s3_compatible || self.no_request_checksum
+    }
+
+    /// Whether to skip precalculated checksum values on uploads.
+    pub fn no_precalculated_checksum(&self) -> bool {
+        self.s3_compatible || self.no_precalculated_checksum
     }
 
     /// Whether to force path-style addressing for the source.
@@ -1325,6 +1358,13 @@ impl Compatibility {
         self.source_s3_compatible || self.source_no_request_checksum || self.no_request_checksum()
     }
 
+    /// Whether to skip precalculated checksum values on uploads for the source.
+    pub fn source_no_precalculated_checksum(&self) -> bool {
+        self.source_s3_compatible
+            || self.source_no_precalculated_checksum
+            || self.no_precalculated_checksum()
+    }
+
     /// Whether to disable checksum mode for the destination.
     pub fn destination_no_checksum_mode(&self) -> bool {
         self.destination_s3_compatible
@@ -1337,6 +1377,13 @@ impl Compatibility {
         self.destination_s3_compatible
             || self.destination_no_request_checksum
             || self.no_request_checksum()
+    }
+
+    /// Whether to skip precalculated checksum values on uploads for the destination.
+    pub fn destination_no_precalculated_checksum(&self) -> bool {
+        self.destination_s3_compatible
+            || self.destination_no_precalculated_checksum
+            || self.no_precalculated_checksum()
     }
 
     /// The SSP configuration for the source.
@@ -1358,12 +1405,14 @@ impl Compatibility {
             || self.source_no_get_object_attributes
             || self.source_no_checksum_mode
             || self.source_no_request_checksum
+            || self.source_no_precalculated_checksum
             || self.source_stalled_stream_protection.is_some()
             || self.destination_s3_compatible
             || self.destination_force_path_style
             || self.destination_no_get_object_attributes
             || self.destination_no_checksum_mode
             || self.destination_no_request_checksum
+            || self.destination_no_precalculated_checksum
             || self.destination_stalled_stream_protection.is_some()
     }
 }

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -9,6 +9,7 @@ use crate::io::S3Client;
 use crate::io::copy::{
     CopyContent, CopyResult, CopyState, MultiPartOptions, ObjectCopy, Part, Reopen,
 };
+use aws_sdk_s3::operation::get_object::GetObjectOutput;
 use aws_sdk_s3::operation::get_object_tagging::{GetObjectTaggingError, GetObjectTaggingOutput};
 use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
 use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
@@ -23,7 +24,7 @@ use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::byte_stream::ByteStream;
 use bytes::Bytes;
 use futures_util::stream::poll_fn;
-use futures_util::{StreamExt, TryStreamExt};
+use futures_util::{Stream, StreamExt, TryStreamExt};
 use http_body::Frame;
 use http_body_util::StreamBody;
 use std::collections::HashMap;
@@ -34,7 +35,7 @@ use std::result;
 use std::sync::{Arc, Mutex};
 use tokio::io::AsyncRead;
 use tokio::sync::mpsc;
-use tokio_util::io::ReaderStream;
+use tokio_util::io::{ReaderStream, StreamReader};
 
 /// The number of chunks buffered when re-trying an SDK body.
 const REOPEN_CHANNEL_CAPACITY: usize = 16;
@@ -247,7 +248,7 @@ impl S3 {
             .ok_or_else(|| Error::aws_error("missing size".to_string()))?;
         let metadata = head.metadata;
 
-        Ok(CopyState::new(size, tags, metadata))
+        Ok(CopyState::new(size, tags, metadata).with_etag(head.e_tag))
     }
 
     /// Get the head object output.
@@ -362,6 +363,7 @@ impl S3 {
 
         let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
         let do_copy = |tagging, tagging_set, metadata, metadata_set, additional_checksum| async {
+            let etag = state.etag();
             self.client
                 .copy_object(move |b| {
                     b.tagging_directive(tagging)
@@ -370,6 +372,7 @@ impl S3 {
                         .set_metadata(metadata_set)
                         .set_checksum_algorithm(additional_checksum)
                         .copy_source(Self::copy_source(&source.key, &source.bucket))
+                        .set_copy_source_if_match(etag)
                         .key(&destination.key)
                         .bucket(&destination.bucket)
                 })
@@ -467,6 +470,7 @@ impl S3 {
             let range = multi_part
                 .format_range()
                 .ok_or_else(|| Error::aws_error("invalid range".to_string()))?;
+            let etag = state.etag();
             let response = self
                 .client
                 .upload_part_copy(|b| {
@@ -475,6 +479,7 @@ impl S3 {
                         .key(&destination.key)
                         .bucket(&destination.bucket)
                         .copy_source(Self::copy_source(&source.key, &source.bucket))
+                        .set_copy_source_if_match(etag)
                         .copy_source_range(range)
                 })
                 .await?;
@@ -504,29 +509,101 @@ impl S3 {
         }
     }
 
-    /// Get the object from S3. The returned content carries a reopen function that re-issues the
-    /// same ranged get.
-    pub async fn get_object(&self, multi_part: Option<MultiPartOptions>) -> Result<CopyContent> {
+    /// Send the ranged `GetObject` request for the source.
+    async fn send_get_object(
+        &self,
+        multi_part: Option<MultiPartOptions>,
+        etag: Option<String>,
+    ) -> Result<GetObjectOutput> {
         let source = self.get_source()?;
+        let range = multi_part
+            .as_ref()
+            .and_then(|multi_part| multi_part.format_range());
 
+        Ok(self
+            .client
+            .get_object(|b| {
+                b.bucket(&source.bucket)
+                    .key(&source.key)
+                    .set_range(range)
+                    .set_if_match(etag)
+            })
+            .await?)
+    }
+
+    /// Stream the chunks of a reader that is only opened when the stream is first polled.
+    fn lazy_reader_stream<F, Fut, R>(
+        open: F,
+    ) -> impl Stream<Item = result::Result<Bytes, io::Error>>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<R>> + Send + 'static,
+        R: AsyncRead + Send + Unpin + 'static,
+    {
+        let (tx, mut rx) =
+            mpsc::channel::<result::Result<Bytes, io::Error>>(REOPEN_CHANNEL_CAPACITY);
+
+        let mut pending = Some((tx, open));
+        poll_fn(move |cx| {
+            if let Some((tx, open)) = pending.take() {
+                tokio::spawn(async move {
+                    match open().await {
+                        Ok(reader) => {
+                            let mut stream =
+                                ReaderStream::with_capacity(reader, READER_STREAM_CAPACITY);
+                            while let Some(chunk) = stream.next().await {
+                                if tx.send(chunk).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            let _ = tx.send(Err(io::Error::other(err.to_string()))).await;
+                        }
+                    }
+                });
+            }
+
+            rx.poll_recv(cx)
+        })
+    }
+
+    /// Wrap the source object in a reader that only sends the `GetObject` request when it is
+    /// first polled.
+    fn lazy_object_reader(
+        &self,
+        multi_part: Option<MultiPartOptions>,
+        etag: Option<String>,
+    ) -> Box<dyn AsyncRead + Sync + Send + Unpin> {
+        let this = self.clone();
+        Box::new(StreamReader::new(Self::lazy_reader_stream(
+            move || async move {
+                Ok(this
+                    .send_get_object(multi_part, etag)
+                    .await?
+                    .body
+                    .into_async_read())
+            },
+        )))
+    }
+
+    /// Get the object from S3. The request is not sent until the content is first read.
+    pub async fn get_object(
+        &self,
+        multi_part: Option<MultiPartOptions>,
+        etag: Option<String>,
+    ) -> Result<CopyContent> {
         if let Some(multipart) = &multi_part
             && multipart.part_number.is_none()
         {
             return Ok(CopyContent::empty());
         }
 
-        let range = multi_part
-            .as_ref()
-            .and_then(|multi_part| multi_part.format_range());
-
-        let result = self
-            .client
-            .get_object(|b| b.bucket(&source.bucket).key(&source.key).set_range(range))
-            .await?;
+        let data = self.lazy_object_reader(multi_part.clone(), etag.clone());
 
         let self_clone = self.clone();
-        CopyContent::builder(Box::new(result.body.into_async_read()))
-            .with_reopen(move || self_clone.reopen_get(multi_part.clone()))
+        CopyContent::builder(data)
+            .with_reopen(move || self_clone.reopen_get(multi_part.clone(), etag.clone()))
             .build()
     }
 
@@ -534,9 +611,10 @@ impl S3 {
     fn reopen_get(
         &self,
         multi_part: Option<MultiPartOptions>,
+        etag: Option<String>,
     ) -> Pin<Box<dyn Future<Output = Result<CopyContent>> + Send>> {
         let self_clone = self.clone();
-        Box::pin(async move { self_clone.get_object(multi_part).await })
+        Box::pin(async move { self_clone.get_object(multi_part, etag).await })
     }
 
     /// Wrap an async reader into an `SdkBody`.
@@ -549,26 +627,11 @@ impl S3 {
     /// Build a streaming `SdkBody` that re-tries its data from the source. This allows the SDK body
     /// to be re-tried automatically when needed.
     fn reopen_body(reopen: Arc<Reopen>) -> SdkBody {
-        let (tx, mut rx) =
-            mpsc::channel::<result::Result<Bytes, io::Error>>(REOPEN_CHANNEL_CAPACITY);
-        tokio::spawn(async move {
-            match (*reopen)().await {
-                Ok(content) => {
-                    let mut stream =
-                        ReaderStream::with_capacity(content.data, READER_STREAM_CAPACITY);
-                    while let Some(chunk) = stream.next().await {
-                        if tx.send(chunk).await.is_err() {
-                            break;
-                        }
-                    }
-                }
-                Err(err) => {
-                    let _ = tx.send(Err(io::Error::other(err.to_string()))).await;
-                }
-            }
-        });
+        // The SDK creates clones of a retryable body per request but only ever polls one of them,
+        // so the reopen call must not be issued until first poll.
+        let stream = Self::lazy_reader_stream(move || async move { Ok((*reopen)().await?.data) })
+            .map_ok(Frame::data);
 
-        let stream = poll_fn(move |cx| rx.poll_recv(cx)).map_ok(Frame::data);
         SdkBody::from_body_1_x(StreamBody::new(stream))
     }
 
@@ -793,8 +856,12 @@ impl ObjectCopy for S3 {
         }
     }
 
-    async fn download(&self, multi_part: Option<MultiPartOptions>) -> Result<CopyContent> {
-        self.get_object(multi_part).await
+    async fn download(
+        &self,
+        multi_part: Option<MultiPartOptions>,
+        state: &CopyState,
+    ) -> Result<CopyContent> {
+        self.get_object(multi_part, state.etag()).await
     }
 
     async fn upload(
@@ -842,6 +909,7 @@ mod test {
     use aws_sdk_s3::Client;
     use aws_sdk_s3::config::SharedAsyncSleep;
     use aws_sdk_s3::config::retry::RetryConfig;
+    use aws_sdk_s3::operation::copy_object::CopyObjectOutput;
     use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
     use aws_sdk_s3::operation::get_object::GetObjectOutput;
     use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
@@ -921,7 +989,7 @@ mod test {
         Fut: Future<Output = Result<CopyResult>>,
     {
         let source = s3_source(retrying_mock_client(&[get_object]));
-        let content = source.download(None).await?;
+        let content = source.download(None, &CopyState::default()).await?;
         upload(content).await
     }
 
@@ -1054,7 +1122,10 @@ mod test {
             end: BODY.len() as u64,
             ..Default::default()
         };
-        let content = source.download(Some(options.clone())).await.unwrap();
+        let content = source
+            .download(Some(options.clone()), &CopyState::default())
+            .await
+            .unwrap();
 
         let destination = s3_destination(
             retrying_mock_client(&[&create, &upload_part]),
@@ -1120,12 +1191,79 @@ mod test {
         let get_object = get_object_rule();
         let source = s3_source(retrying_mock_client(&[&get_object]));
 
-        let content = source.download(None).await.unwrap();
+        let content = source.download(None, &CopyState::default()).await.unwrap();
         let mut reopened = (content.reopen)().await.unwrap();
 
         let mut buf = Vec::new();
         reopened.data.read_to_end(buf.as_mut()).await.unwrap();
         assert_eq!(buf, BODY);
+    }
+
+    #[tokio::test]
+    async fn download_is_lazy() {
+        let get_object = get_object_rule();
+        let source = s3_source(retrying_mock_client(&[&get_object]));
+
+        let mut content = source.download(None, &CopyState::default()).await.unwrap();
+        assert_eq!(get_object.num_calls(), 0);
+
+        let mut buf = Vec::new();
+        content.data.read_to_end(buf.as_mut()).await.unwrap();
+        assert_eq!(buf, BODY);
+        assert_eq!(get_object.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_object_sets_if_etag() {
+        let get_object = mock!(Client::get_object)
+            .match_requests(|req| {
+                req.bucket() == Some(BUCKET)
+                    && req.key() == Some(KEY)
+                    && req.if_match() == Some("etag")
+            })
+            .sequence()
+            .output(|| {
+                GetObjectOutput::builder()
+                    .body(ByteStream::from_static(BODY))
+                    .build()
+            })
+            .repeatedly()
+            .build();
+        let source = s3_source(retrying_mock_client(&[&get_object]));
+
+        let state = CopyState::default().with_etag(Some("etag".to_string()));
+        let mut content = source.download(None, &state).await.unwrap();
+
+        let mut buf = Vec::new();
+        content.data.read_to_end(buf.as_mut()).await.unwrap();
+        assert_eq!(buf, BODY);
+        assert_eq!(get_object.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn copy_object_sets_if_etag() {
+        let copy = mock!(Client::copy_object)
+            .match_requests(|req| req.copy_source_if_match() == Some("etag"))
+            .sequence()
+            .output(|| CopyObjectOutput::builder().build())
+            .repeatedly()
+            .build();
+
+        let s3 = S3Builder::default()
+            .with_client(S3Client::new(
+                Arc::new(retrying_mock_client(&[&copy])),
+                false,
+                false,
+            ))
+            .with_copy_tags(MetadataCopy::Copy)
+            .with_source(BUCKET, KEY)
+            .with_destination(BUCKET, KEY)
+            .build()
+            .unwrap();
+
+        let state = copy_state().with_etag(Some("etag".to_string()));
+        s3.copy_object(&state).await.unwrap();
+        assert_eq!(copy.num_calls(), 1);
     }
 
     /// Build an S3 source with a specific tag_mode from a mock client.

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -392,9 +392,13 @@ impl S3 {
     }
 
     /// The additional checksum to attach to an upload.
-    fn upload_checksum(state: &CopyState) -> UploadChecksum {
+    fn upload_checksum(&self, state: &CopyState) -> UploadChecksum {
         if let Some(algorithm) = Self::additional_checksum_algorithm(state) {
             UploadChecksum::Computed(algorithm)
+        } else if self.client.no_precalculated_checksum() {
+            // Some endpoints reject uploads that declare checksum algorithms which are not
+            // computed by the SDK, so no additional checksum can be applied here.
+            UploadChecksum::None
         } else if let Some((ctx, sum)) = Self::precalculated_sum(state) {
             UploadChecksum::Precalculated(Box::new(ctx), sum)
         } else {
@@ -510,7 +514,7 @@ impl S3 {
                 &destination.bucket,
                 tagging,
                 state.metadata(),
-                Self::upload_checksum(state),
+                self.upload_checksum(state),
             )
             .await?
         };
@@ -552,7 +556,7 @@ impl S3 {
                 &destination.bucket,
                 upload_id.to_string(),
                 parts,
-                Self::upload_checksum(state),
+                self.upload_checksum(state),
             )
             .await?;
 
@@ -718,7 +722,7 @@ impl S3 {
             Self::upload_body(content),
             state.tags(),
             state.metadata(),
-            Self::upload_checksum(state),
+            self.upload_checksum(state),
             i64::try_from(state.size())?,
         )
         .await?;
@@ -771,7 +775,7 @@ impl S3 {
         state: &CopyState,
     ) -> Result<CopyResult> {
         let destination = self.get_destination()?;
-        let checksum = Self::upload_checksum(state);
+        let checksum = self.upload_checksum(state);
         let content_length = i64::try_from(state.size())?;
 
         let CopyContent { data, reopen } = content;
@@ -830,7 +834,7 @@ impl S3 {
                 &destination.bucket,
                 state.tags(),
                 state.metadata(),
-                Self::upload_checksum(state),
+                self.upload_checksum(state),
             )
             .await?
         };
@@ -867,7 +871,7 @@ impl S3 {
                 &destination.bucket,
                 upload_id.to_string(),
                 parts,
-                Self::upload_checksum(state),
+                self.upload_checksum(state),
             )
             .await?;
 
@@ -1057,6 +1061,18 @@ mod test {
         S3Builder::default()
             .with_client(S3Client::new(Arc::new(client), false, false))
             .with_copy_tags(tag_mode)
+            .with_destination(BUCKET, KEY)
+            .build()
+            .unwrap()
+    }
+
+    /// Build an S3 destination from a mock client with precalculated checksums disabled.
+    fn s3_destination_no_precalculated(client: Client) -> S3 {
+        S3Builder::default()
+            .with_client(
+                S3Client::new(Arc::new(client), false, false).with_no_precalculated_checksum(true),
+            )
+            .with_copy_tags(MetadataCopy::Copy)
             .with_destination(BUCKET, KEY)
             .build()
             .unwrap()
@@ -1630,6 +1646,95 @@ mod test {
             .await
             .unwrap();
 
+        assert_eq!(complete.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn put_object_no_precalculated_checksum_omits_sum() {
+        let put_object = mock!(Client::put_object)
+            .match_requests(|req| {
+                req.checksum_md5().is_none() && req.checksum_algorithm().is_none()
+            })
+            .sequence()
+            .output(|| PutObjectOutput::builder().build())
+            .build();
+
+        let get_object = get_object_rule();
+        let state = copy_state_with_ctx("md5", Some(EXPECTED_MD5_SUM));
+        download(&get_object, |content| {
+            let destination = s3_destination_no_precalculated(retrying_mock_client(&[&put_object]));
+            async move { destination.put_object(content, &state).await }
+        })
+        .await
+        .unwrap();
+        assert_eq!(put_object.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn multipart_no_precalculated_checksum_omits_declaration() {
+        let create = mock!(Client::create_multipart_upload)
+            .match_requests(|req| {
+                req.checksum_algorithm().is_none() && req.checksum_type().is_none()
+            })
+            .sequence()
+            .output(|| {
+                CreateMultipartUploadOutput::builder()
+                    .upload_id("upload-id")
+                    .build()
+            })
+            .build();
+        let upload_part = mock!(Client::upload_part)
+            .match_requests(|req| req.checksum_algorithm().is_none())
+            .sequence()
+            .output(|| UploadPartOutput::builder().e_tag("etag").build())
+            .build();
+        let complete = mock!(Client::complete_multipart_upload)
+            .match_requests(|req| req.checksum_md5().is_none() && req.checksum_type().is_none())
+            .sequence()
+            .output(|| CompleteMultipartUploadOutput::builder().build())
+            .build();
+
+        let state = copy_state_with_ctx("md5", Some(EXPECTED_MD5_SUM));
+        let get_object = get_object_rule();
+        let source = s3_source(retrying_mock_client(&[&get_object]));
+        let options = MultiPartOptions {
+            part_number: Some(1),
+            start: 0,
+            end: BODY.len() as u64,
+            ..Default::default()
+        };
+        let content = source
+            .download(Some(options.clone()), &CopyState::default())
+            .await
+            .unwrap();
+
+        let destination = s3_destination_no_precalculated(retrying_mock_client(&[
+            &create,
+            &upload_part,
+            &complete,
+        ]));
+        destination
+            .put_object_multipart(content, options, &state)
+            .await
+            .unwrap();
+
+        let completion = MultiPartOptions {
+            part_number: None,
+            upload_id: Some("upload-id".to_string()),
+            parts: Some(vec![Part {
+                part_number: 1,
+                e_tag: Some("etag".to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        destination
+            .put_object_multipart(CopyContent::empty(), completion, &state)
+            .await
+            .unwrap();
+
+        assert_eq!(create.num_calls(), 1);
+        assert_eq!(upload_part.num_calls(), 1);
         assert_eq!(complete.num_calls(), 1);
     }
 

--- a/copyrite/src/io/copy/aws.rs
+++ b/copyrite/src/io/copy/aws.rs
@@ -1,7 +1,9 @@
 //! AWS checksums and functionality.
 //!
 
+use crate::checksum::Ctx;
 use crate::checksum::file::SumsFile;
+use crate::checksum::standard::StandardCtx;
 use crate::cli::MetadataCopy;
 use crate::error::Error::{CopyError, ParseError};
 use crate::error::{ApiError, Error, Result};
@@ -15,13 +17,15 @@ use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
 use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
 use aws_sdk_s3::operation::upload_part::UploadPartOutput;
 use aws_sdk_s3::types::{
-    ChecksumAlgorithm, CompletedMultipartUpload, CompletedPart, CopyPartResult, MetadataDirective,
-    TaggingDirective,
+    ChecksumAlgorithm, ChecksumType, CompletedMultipartUpload, CompletedPart, CopyPartResult,
+    MetadataDirective, TaggingDirective,
 };
 use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use aws_smithy_runtime_api::client::result::SdkError;
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::byte_stream::ByteStream;
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 use bytes::Bytes;
 use futures_util::stream::poll_fn;
 use futures_util::{Stream, StreamExt, TryStreamExt};
@@ -198,6 +202,17 @@ impl TryFrom<Part> for CompletedPart {
     }
 }
 
+/// The additional checksum to attach to an upload.
+#[derive(Debug, Clone)]
+enum UploadChecksum {
+    /// An algorithm the SDK computes while streaming the upload.
+    Computed(ChecksumAlgorithm),
+    /// A precalculated base64 digest for an algorithm.
+    Precalculated(Box<StandardCtx>, String),
+    /// No additional checksum applies to this upload.
+    None,
+}
+
 /// Represents an S3 bucket and key.
 #[derive(Debug, Clone)]
 pub struct BucketKey {
@@ -289,41 +304,39 @@ impl S3 {
     }
 
     /// Create a new multipart upload.
-    pub async fn get_multipart_upload(
+    async fn get_multipart_upload(
         &self,
         key: &str,
         bucket: &str,
         tagging: Option<String>,
         metadata: Option<HashMap<String, String>>,
-        additional_checksum: Option<ChecksumAlgorithm>,
+        checksum: UploadChecksum,
     ) -> Result<(String, Vec<ApiError>)> {
-        let do_upload = |tagging, metadata, additional_checksum| async {
+        let do_upload = |tagging, metadata, checksum: UploadChecksum| async {
             self.client
                 .create_multipart_upload(|b| {
+                    let b = match checksum {
+                        UploadChecksum::Computed(algorithm) => b.checksum_algorithm(algorithm),
+                        UploadChecksum::Precalculated(ctx, _) => b
+                            .checksum_algorithm(ChecksumAlgorithm::from(Ctx::Regular(*ctx)))
+                            .checksum_type(ChecksumType::FullObject),
+                        UploadChecksum::None => b,
+                    };
                     b.set_tagging(tagging)
                         .set_metadata(metadata)
-                        .set_checksum_algorithm(additional_checksum)
                         .bucket(bucket)
                         .key(key)
                 })
                 .await
         };
 
-        let result = do_upload(
-            tagging.clone(),
-            metadata.clone(),
-            additional_checksum.clone(),
-        )
-        .await;
+        let result = do_upload(tagging.clone(), metadata.clone(), checksum.clone()).await;
 
         // Retry if this is a best effort copy and the error was access denied.
         let (upload, err) = if let Err(ref err) = result {
             let err = ApiError::from(err);
             if self.tag_mode.is_best_effort() && err.is_access_denied() {
-                (
-                    do_upload(None, metadata, additional_checksum).await?,
-                    vec![err],
-                )
+                (do_upload(None, metadata, checksum).await?, vec![err])
             } else {
                 (result?, vec![])
             }
@@ -351,6 +364,44 @@ impl S3 {
             .ok_or_else(|| CopyError("missing destination".to_string()))
     }
 
+    /// The additional checksum algorithm for the SDK or S3 to compute during an upload or copy.
+    fn additional_checksum_algorithm(state: &CopyState) -> Option<ChecksumAlgorithm> {
+        state
+            .additional_ctx()
+            .map(Ctx::into_standard)
+            .filter(StandardCtx::is_sdk_computable_ctx)
+            .map(|ctx| ChecksumAlgorithm::from(Ctx::Regular(ctx)))
+    }
+
+    /// A precalculated additional checksum for algorithms that S3 accepts but the SDK cannot
+    /// compute during an upload.
+    fn precalculated_sum(state: &CopyState) -> Option<(StandardCtx, String)> {
+        let ctx = match state.additional_ctx()? {
+            Ctx::Regular(ctx) => ctx,
+            Ctx::AWSEtag(_) => return None,
+        };
+        if ctx.is_sdk_computable_ctx() || !ctx.is_aws_additional_ctx() {
+            return None;
+        }
+
+        // S3 validates the value against the algorithm, so an incorrect sum fails the request
+        // rather than storing a bad checksum.
+        let digest = hex::decode(state.additional_sum()?).ok()?;
+
+        Some((ctx, BASE64_STANDARD.encode(digest)))
+    }
+
+    /// The additional checksum to attach to an upload.
+    fn upload_checksum(state: &CopyState) -> UploadChecksum {
+        if let Some(algorithm) = Self::additional_checksum_algorithm(state) {
+            UploadChecksum::Computed(algorithm)
+        } else if let Some((ctx, sum)) = Self::precalculated_sum(state) {
+            UploadChecksum::Precalculated(Box::new(ctx), sum)
+        } else {
+            UploadChecksum::None
+        }
+    }
+
     /// Copy the object using the `CopyObject` operation.
     pub async fn copy_object(&self, state: &CopyState) -> Result<CopyResult> {
         let size = state.size();
@@ -361,7 +412,8 @@ impl S3 {
         let source = self.get_source()?;
         let destination = self.get_destination()?;
 
-        let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
+        // When no algorithm is set S3 copies the checksum algorithm from the source object.
+        let additional_checksum = Self::additional_checksum_algorithm(state);
         let do_copy = |tagging, tagging_set, metadata, metadata_set, additional_checksum| async {
             let etag = state.etag();
             self.client
@@ -449,8 +501,6 @@ impl S3 {
         let source = self.get_source()?;
         let destination = self.get_destination()?;
 
-        let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
-
         // Create the upload id if it doesn't exist or use the existing one.
         let (upload_id, api_errors) = if let Some(upload_id) = &multi_part.upload_id {
             (upload_id.to_string(), vec![])
@@ -460,7 +510,7 @@ impl S3 {
                 &destination.bucket,
                 tagging,
                 state.metadata(),
-                additional_checksum,
+                Self::upload_checksum(state),
             )
             .await?
         };
@@ -502,6 +552,7 @@ impl S3 {
                 &destination.bucket,
                 upload_id.to_string(),
                 parts,
+                Self::upload_checksum(state),
             )
             .await?;
 
@@ -667,7 +718,7 @@ impl S3 {
             Self::upload_body(content),
             state.tags(),
             state.metadata(),
-            state.additional_ctx().map(ChecksumAlgorithm::from),
+            Self::upload_checksum(state),
             i64::try_from(state.size())?,
         )
         .await?;
@@ -682,16 +733,28 @@ impl S3 {
         body: ByteStream,
         tags: Option<String>,
         metadata: Option<HashMap<String, String>>,
-        additional_checksum: Option<ChecksumAlgorithm>,
+        checksum: UploadChecksum,
         content_length: i64,
     ) -> result::Result<PutObjectOutput, SdkError<PutObjectError, HttpResponse>> {
         let bucket = destination.bucket.clone();
         let key = destination.key.clone();
         self.client
             .put_object(move |b| {
+                // S3 validates the uploaded data against a precalculated checksum.
+                let b = match checksum {
+                    UploadChecksum::Computed(algorithm) => b.checksum_algorithm(algorithm),
+                    UploadChecksum::Precalculated(ctx, sum) => match *ctx {
+                        StandardCtx::MD5(_) => b.checksum_md5(sum),
+                        StandardCtx::SHA512(_) => b.checksum_sha512(sum),
+                        StandardCtx::XXHash64(_) => b.checksum_xxhash64(sum),
+                        StandardCtx::XXHash3(_) => b.checksum_xxhash3(sum),
+                        StandardCtx::XXHash128(_) => b.checksum_xxhash128(sum),
+                        _ => b,
+                    },
+                    UploadChecksum::None => b,
+                };
                 b.set_tagging(tags)
                     .set_metadata(metadata)
-                    .set_checksum_algorithm(additional_checksum)
                     .content_length(content_length)
                     .bucket(bucket)
                     .key(key)
@@ -708,7 +771,7 @@ impl S3 {
         state: &CopyState,
     ) -> Result<CopyResult> {
         let destination = self.get_destination()?;
-        let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
+        let checksum = Self::upload_checksum(state);
         let content_length = i64::try_from(state.size())?;
 
         let CopyContent { data, reopen } = content;
@@ -720,7 +783,7 @@ impl S3 {
                 Self::retryable_body(Some(data), Arc::clone(&reopen)),
                 state.tags(),
                 state.metadata(),
-                additional_checksum.clone(),
+                checksum.clone(),
                 content_length,
             )
             .await;
@@ -741,7 +804,7 @@ impl S3 {
             Self::retryable_body(None, reopen),
             None,
             state.metadata(),
-            additional_checksum,
+            checksum,
             content_length,
         )
         .await?;
@@ -758,7 +821,6 @@ impl S3 {
     ) -> Result<CopyResult> {
         let destination = self.get_destination()?;
 
-        let additional_checksum = state.additional_ctx().map(ChecksumAlgorithm::from);
         // Create the upload id if it doesn't exist or use the existing one.
         let (upload_id, err) = if let Some(upload_id) = multi_part.upload_id.as_ref() {
             (upload_id.to_string(), vec![])
@@ -768,7 +830,7 @@ impl S3 {
                 &destination.bucket,
                 state.tags(),
                 state.metadata(),
-                additional_checksum.clone(),
+                Self::upload_checksum(state),
             )
             .await?
         };
@@ -776,6 +838,8 @@ impl S3 {
         if let Some(part_number) = multi_part.part_number {
             let part_number_i32 = i32::try_from(part_number)?;
             let content_length = i64::try_from(multi_part.bytes_transferred())?;
+            // Only SDK-computable algorithms have trailers.
+            let additional_checksum = Self::additional_checksum_algorithm(state);
             let part = self
                 .client
                 .upload_part(|b| {
@@ -803,6 +867,7 @@ impl S3 {
                 &destination.bucket,
                 upload_id.to_string(),
                 parts,
+                Self::upload_checksum(state),
             )
             .await?;
 
@@ -817,6 +882,7 @@ impl S3 {
         bucket: &str,
         upload_id: String,
         mut parts: Vec<Part>,
+        checksum: UploadChecksum,
     ) -> Result<()> {
         // Parts must be ordered.
         parts.sort_by_key(|a| a.part_number);
@@ -827,6 +893,21 @@ impl S3 {
             .collect::<Result<Vec<_>>>()?;
         self.client
             .complete_multipart_upload(|b| {
+                // A precalculated value covers the whole object, which S3 verifies before completing.
+                let b = match checksum {
+                    UploadChecksum::Precalculated(ctx, sum) => {
+                        let b = match *ctx {
+                            StandardCtx::MD5(_) => b.checksum_md5(sum),
+                            StandardCtx::SHA512(_) => b.checksum_sha512(sum),
+                            StandardCtx::XXHash64(_) => b.checksum_xxhash64(sum),
+                            StandardCtx::XXHash3(_) => b.checksum_xxhash3(sum),
+                            StandardCtx::XXHash128(_) => b.checksum_xxhash128(sum),
+                            _ => b,
+                        };
+                        b.checksum_type(ChecksumType::FullObject)
+                    }
+                    _ => b,
+                };
                 b.bucket(bucket)
                     .key(key)
                     .multipart_upload(
@@ -905,15 +986,18 @@ impl ObjectCopy for S3 {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::checksum::standard::test::EXPECTED_MD5_SUM;
     use crate::io::copy::CopyContent;
     use aws_sdk_s3::Client;
     use aws_sdk_s3::config::SharedAsyncSleep;
     use aws_sdk_s3::config::retry::RetryConfig;
+    use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadOutput;
     use aws_sdk_s3::operation::copy_object::CopyObjectOutput;
     use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
     use aws_sdk_s3::operation::get_object::GetObjectOutput;
     use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
     use aws_sdk_s3::operation::upload_part::UploadPartOutput;
+    use aws_sdk_s3::operation::upload_part_copy::UploadPartCopyOutput;
     use aws_smithy_async::rt::sleep::TokioSleep;
     use aws_smithy_mocks::{MockResponseInterceptor, Rule, RuleMode, mock};
     use aws_smithy_types::byte_stream::ByteStream;
@@ -924,6 +1008,7 @@ mod test {
     const BUCKET: &str = "bucket";
     const KEY: &str = "key";
     const BODY: &[u8] = b"test";
+    const XXHASH64_SUM: &str = "ef46db3751d8e999"; // pragma: allowlist secret
 
     /// Build a mock client that enables real retries with backoff so the SDK retry layer actually
     /// re-drives the request body through the reopen factory.
@@ -982,6 +1067,14 @@ mod test {
         CopyState::new(BODY.len() as u64, Some("tag=value".to_string()), None)
     }
 
+    /// Test copy state with an additional checksum context and known sum.
+    fn copy_state_with_ctx(ctx: &str, sum: Option<&str>) -> CopyState {
+        let mut state = copy_state();
+        state.set_additional_ctx(ctx.parse().unwrap());
+        state.set_additional_sum(sum.map(|sum| sum.to_string()));
+        state
+    }
+
     /// Download the mock source.
     async fn download<F, Fut>(get_object: &Rule, upload: F) -> Result<CopyResult>
     where
@@ -1022,6 +1115,38 @@ mod test {
             .http_status(503, None)
             .repeatedly()
             .build()
+    }
+
+    /// Upload the mock source with the state's additional checksum applied.
+    async fn test_put_with_state(put_object: &Rule, state: CopyState) -> Result<CopyResult> {
+        let get_object = get_object_rule();
+        download(&get_object, |content| {
+            let destination =
+                s3_destination(retrying_mock_client(&[put_object]), MetadataCopy::Copy);
+            async move { destination.put_object(content, &state).await }
+        })
+        .await
+    }
+
+    /// Build an S3 source with a specific tag_mode from a mock client.
+    fn s3_source_with_tag_mode(client: Client, tag_mode: MetadataCopy) -> S3 {
+        S3Builder::default()
+            .with_client(S3Client::new(Arc::new(client), false, false))
+            .with_copy_tags(tag_mode)
+            .with_source(BUCKET, KEY)
+            .build()
+            .unwrap()
+    }
+
+    /// A `head_object` rule that returns a valid output with content_length set.
+    fn head_object_rule() -> Rule {
+        mock!(Client::head_object)
+            .match_requests(|req| req.bucket() == Some(BUCKET) && req.key() == Some(KEY))
+            .then_output(|| {
+                HeadObjectOutput::builder()
+                    .content_length(BODY.len() as i64)
+                    .build()
+            })
     }
 
     #[tokio::test]
@@ -1266,25 +1391,246 @@ mod test {
         assert_eq!(copy.num_calls(), 1);
     }
 
-    /// Build an S3 source with a specific tag_mode from a mock client.
-    fn s3_source_with_tag_mode(client: Client, tag_mode: MetadataCopy) -> S3 {
-        S3Builder::default()
-            .with_client(S3Client::new(Arc::new(client), false, false))
-            .with_copy_tags(tag_mode)
-            .with_source(BUCKET, KEY)
-            .build()
-            .unwrap()
+    #[tokio::test]
+    async fn put_object_md5_uses_precalculated_sum() {
+        let expected = BASE64_STANDARD.encode(hex::decode(EXPECTED_MD5_SUM).unwrap());
+        let put_object = mock!(Client::put_object)
+            .match_requests(move |req| {
+                req.checksum_md5() == Some(expected.as_str()) && req.checksum_algorithm().is_none()
+            })
+            .sequence()
+            .output(|| PutObjectOutput::builder().build())
+            .build();
+
+        let state = copy_state_with_ctx("md5", Some(EXPECTED_MD5_SUM));
+        test_put_with_state(&put_object, state).await.unwrap();
+        assert_eq!(put_object.num_calls(), 1);
     }
 
-    /// A `head_object` rule that returns a valid output with content_length set.
-    fn head_object_rule() -> Rule {
-        mock!(Client::head_object)
-            .match_requests(|req| req.bucket() == Some(BUCKET) && req.key() == Some(KEY))
-            .then_output(|| {
-                HeadObjectOutput::builder()
-                    .content_length(BODY.len() as i64)
+    #[tokio::test]
+    async fn put_object_xxhash64_uses_precalculated_sum() {
+        let expected = BASE64_STANDARD.encode(hex::decode(XXHASH64_SUM).unwrap());
+        let put_object = mock!(Client::put_object)
+            .match_requests(move |req| {
+                req.checksum_xxhash64() == Some(expected.as_str())
+                    && req.checksum_algorithm().is_none()
+            })
+            .sequence()
+            .output(|| PutObjectOutput::builder().build())
+            .build();
+
+        let state = copy_state_with_ctx("xxhash64", Some(XXHASH64_SUM));
+        test_put_with_state(&put_object, state).await.unwrap();
+        assert_eq!(put_object.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn put_object_computable_ctx_sets_algorithm() {
+        let put_object = mock!(Client::put_object)
+            .match_requests(|req| {
+                req.checksum_algorithm() == Some(&ChecksumAlgorithm::Crc32)
+                    && req.checksum_md5().is_none()
+            })
+            .sequence()
+            .output(|| PutObjectOutput::builder().build())
+            .build();
+
+        // A computable checksum uses the SDK trailer even when the sum value is known.
+        let state = copy_state_with_ctx("crc32", Some("00000000"));
+        test_put_with_state(&put_object, state).await.unwrap();
+        assert_eq!(put_object.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn put_object_skips_non_hex_precalculated_sum() {
+        let put_object = mock!(Client::put_object)
+            .match_requests(|req| {
+                req.checksum_md5().is_none() && req.checksum_algorithm().is_none()
+            })
+            .sequence()
+            .output(|| PutObjectOutput::builder().build())
+            .build();
+
+        // The digest cannot be decoded, so no checksum can be applied.
+        let state = copy_state_with_ctx("md5", Some("zzzz"));
+        test_put_with_state(&put_object, state).await.unwrap();
+        assert_eq!(put_object.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn copy_object_md5_omits_checksum_algorithm() {
+        let copy = mock!(Client::copy_object)
+            .match_requests(|req| req.checksum_algorithm().is_none())
+            .sequence()
+            .output(|| CopyObjectOutput::builder().build())
+            .repeatedly()
+            .build();
+
+        let s3 = S3Builder::default()
+            .with_client(S3Client::new(
+                Arc::new(retrying_mock_client(&[&copy])),
+                false,
+                false,
+            ))
+            .with_copy_tags(MetadataCopy::Copy)
+            .with_source(BUCKET, KEY)
+            .with_destination(BUCKET, KEY)
+            .build()
+            .unwrap();
+
+        let state = copy_state_with_ctx("md5", Some(EXPECTED_MD5_SUM));
+        s3.copy_object(&state).await.unwrap();
+        assert_eq!(copy.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn multipart_md5_algorithm_completes() {
+        let expected = BASE64_STANDARD.encode(hex::decode(EXPECTED_MD5_SUM).unwrap());
+        let create = mock!(Client::create_multipart_upload)
+            .match_requests(|req| {
+                req.checksum_algorithm() == Some(&ChecksumAlgorithm::Md5)
+                    && req.checksum_type() == Some(&ChecksumType::FullObject)
+            })
+            .sequence()
+            .output(|| {
+                CreateMultipartUploadOutput::builder()
+                    .upload_id("upload-id")
                     .build()
             })
+            .build();
+        let upload_part = mock!(Client::upload_part)
+            .match_requests(|req| req.checksum_algorithm().is_none())
+            .sequence()
+            .output(|| UploadPartOutput::builder().e_tag("etag").build())
+            .build();
+        let complete = mock!(Client::complete_multipart_upload)
+            .match_requests(move |req| {
+                req.checksum_md5() == Some(expected.as_str())
+                    && req.checksum_type() == Some(&ChecksumType::FullObject)
+            })
+            .sequence()
+            .output(|| CompleteMultipartUploadOutput::builder().build())
+            .build();
+
+        let state = copy_state_with_ctx("md5", Some(EXPECTED_MD5_SUM));
+        let get_object = get_object_rule();
+        let source = s3_source(retrying_mock_client(&[&get_object]));
+        let options = MultiPartOptions {
+            part_number: Some(1),
+            start: 0,
+            end: BODY.len() as u64,
+            ..Default::default()
+        };
+        let content = source
+            .download(Some(options.clone()), &CopyState::default())
+            .await
+            .unwrap();
+
+        let destination = s3_destination(
+            retrying_mock_client(&[&create, &upload_part, &complete]),
+            MetadataCopy::Copy,
+        );
+        destination
+            .put_object_multipart(content, options, &state)
+            .await
+            .unwrap();
+
+        let completion = MultiPartOptions {
+            part_number: None,
+            upload_id: Some("upload-id".to_string()),
+            parts: Some(vec![Part {
+                part_number: 1,
+                e_tag: Some("etag".to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        destination
+            .put_object_multipart(CopyContent::empty(), completion, &state)
+            .await
+            .unwrap();
+
+        assert_eq!(create.num_calls(), 1);
+        assert_eq!(upload_part.num_calls(), 1);
+        assert_eq!(complete.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn multipart_copy_md5_without_sum_omits_algorithm() {
+        let create = mock!(Client::create_multipart_upload)
+            .match_requests(|req| {
+                req.checksum_algorithm().is_none() && req.checksum_type().is_none()
+            })
+            .sequence()
+            .output(|| {
+                CreateMultipartUploadOutput::builder()
+                    .upload_id("upload-id")
+                    .build()
+            })
+            .build();
+        let upload_part_copy = mock!(Client::upload_part_copy)
+            .match_requests(|req| req.bucket() == Some(BUCKET) && req.key() == Some(KEY))
+            .sequence()
+            .output(|| {
+                UploadPartCopyOutput::builder()
+                    .copy_part_result(CopyPartResult::builder().e_tag("etag").build())
+                    .build()
+            })
+            .build();
+
+        let s3 = S3Builder::default()
+            .with_client(S3Client::new(
+                Arc::new(retrying_mock_client(&[&create, &upload_part_copy])),
+                false,
+                false,
+            ))
+            .with_copy_tags(MetadataCopy::Copy)
+            .with_source(BUCKET, KEY)
+            .with_destination(BUCKET, KEY)
+            .build()
+            .unwrap();
+
+        // Without a known sum no additional checksum can be applied, so the create request
+        // must not declare an algorithm for a checksum the SDK cannot compute.
+        let state = copy_state_with_ctx("md5", None);
+        let options = MultiPartOptions {
+            part_number: Some(1),
+            start: 0,
+            end: BODY.len() as u64,
+            ..Default::default()
+        };
+        s3.copy_object_multipart(options, &state).await.unwrap();
+
+        assert_eq!(create.num_calls(), 1);
+        assert_eq!(upload_part_copy.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn multipart_ctx_completes_without_precalculated_sum() {
+        let complete = mock!(Client::complete_multipart_upload)
+            .match_requests(|req| req.checksum_sha256().is_none() && req.checksum_type().is_none())
+            .sequence()
+            .output(|| CompleteMultipartUploadOutput::builder().build())
+            .build();
+
+        let destination = s3_destination(retrying_mock_client(&[&complete]), MetadataCopy::Copy);
+        let state = copy_state_with_ctx("sha256", None);
+        let completion = MultiPartOptions {
+            part_number: None,
+            upload_id: Some("upload-id".to_string()),
+            parts: Some(vec![Part {
+                part_number: 1,
+                e_tag: Some("etag".to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        destination
+            .put_object_multipart(CopyContent::empty(), completion, &state)
+            .await
+            .unwrap();
+
+        assert_eq!(complete.num_calls(), 1);
     }
 
     /// Preservation: tag_mode = Copy with successful GetObjectTagging returns formatted tags.

--- a/copyrite/src/io/copy/file.rs
+++ b/copyrite/src/io/copy/file.rs
@@ -197,7 +197,11 @@ impl ObjectCopy for File {
         CopyResult::new(None, None, bytes, vec![])
     }
 
-    async fn download(&self, multipart: Option<MultiPartOptions>) -> Result<CopyContent> {
+    async fn download(
+        &self,
+        multipart: Option<MultiPartOptions>,
+        _state: &CopyState,
+    ) -> Result<CopyContent> {
         self.read(multipart).await
     }
 
@@ -262,10 +266,10 @@ mod test {
         let source = write_source(tmp.path()).await;
         let file = File::new(Some(source), None);
 
-        let content = file.download(None).await.unwrap();
+        let content = file.download(None, &CopyState::default()).await.unwrap();
         assert_eq!(read_all(content).await, BODY);
 
-        let content = file.download(None).await.unwrap();
+        let content = file.download(None, &CopyState::default()).await.unwrap();
         let reopened = (content.reopen)().await.unwrap();
         assert_eq!(read_all(reopened).await, BODY);
     }
@@ -284,11 +288,17 @@ mod test {
         };
         let expected = &BODY[4..19];
 
-        let content = file.download(Some(options.clone())).await.unwrap();
+        let content = file
+            .download(Some(options.clone()), &CopyState::default())
+            .await
+            .unwrap();
         assert_eq!(read_all(content).await, expected);
 
         // Reopen must re-read the identical range.
-        let content = file.download(Some(options)).await.unwrap();
+        let content = file
+            .download(Some(options), &CopyState::default())
+            .await
+            .unwrap();
         let reopened = (content.reopen)().await.unwrap();
         assert_eq!(read_all(reopened).await, expected);
     }
@@ -327,13 +337,19 @@ mod test {
             ..Default::default()
         };
 
-        let content = source.download(Some(part1.clone())).await.unwrap();
+        let content = source
+            .download(Some(part1.clone()), &CopyState::default())
+            .await
+            .unwrap();
         destination
             .upload(content, Some(part1), &state)
             .await
             .unwrap();
 
-        let content = source.download(Some(part2.clone())).await.unwrap();
+        let content = source
+            .download(Some(part2.clone()), &CopyState::default())
+            .await
+            .unwrap();
         destination
             .upload(content, Some(part2), &state)
             .await
@@ -359,7 +375,10 @@ mod test {
         let destination_file = File::new(None, Some(destination.to_string_lossy().to_string()));
         let state = CopyState::new(BODY.len() as u64, None, None);
 
-        let content = source_file.download(None).await.unwrap();
+        let content = source_file
+            .download(None, &CopyState::default())
+            .await
+            .unwrap();
         destination_file
             .upload(content, None, &state)
             .await

--- a/copyrite/src/io/copy/mod.rs
+++ b/copyrite/src/io/copy/mod.rs
@@ -165,6 +165,7 @@ pub struct CopyState {
     tags: Option<String>,
     metadata: Option<HashMap<String, String>>,
     additional_ctx: Option<Ctx>,
+    additional_sum: Option<String>,
     etag: Option<String>,
 }
 
@@ -189,6 +190,11 @@ impl CopyState {
         self.additional_ctx.clone()
     }
 
+    /// Get the known value of the additional checksum.
+    pub fn additional_sum(&self) -> Option<String> {
+        self.additional_sum.clone()
+    }
+
     /// Get the source ETag on state initialized.
     pub fn etag(&self) -> Option<String> {
         self.etag.clone()
@@ -201,6 +207,7 @@ impl CopyState {
             tags,
             metadata,
             additional_ctx: None,
+            additional_sum: None,
             etag: None,
         }
     }
@@ -214,6 +221,11 @@ impl CopyState {
     /// Set the additional context.
     pub fn set_additional_ctx(&mut self, additional_ctx: Ctx) {
         self.additional_ctx = Some(additional_ctx);
+    }
+
+    /// Set the known value of the additional checksum from the source sums file.
+    pub fn set_additional_sum(&mut self, additional_sum: Option<String>) {
+        self.additional_sum = additional_sum;
     }
 }
 

--- a/copyrite/src/io/copy/mod.rs
+++ b/copyrite/src/io/copy/mod.rs
@@ -159,12 +159,13 @@ impl From<(Part, String)> for CopyResult {
 }
 
 /// The state of the copy operation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CopyState {
     size: u64,
     tags: Option<String>,
     metadata: Option<HashMap<String, String>>,
     additional_ctx: Option<Ctx>,
+    etag: Option<String>,
 }
 
 impl CopyState {
@@ -188,6 +189,11 @@ impl CopyState {
         self.additional_ctx.clone()
     }
 
+    /// Get the source ETag on state initialized.
+    pub fn etag(&self) -> Option<String> {
+        self.etag.clone()
+    }
+
     /// Create a new state.
     pub fn new(size: u64, tags: Option<String>, metadata: Option<HashMap<String, String>>) -> Self {
         Self {
@@ -195,7 +201,14 @@ impl CopyState {
             tags,
             metadata,
             additional_ctx: None,
+            etag: None,
         }
+    }
+
+    /// Set the source ETag.
+    pub fn with_etag(mut self, etag: Option<String>) -> Self {
+        self.etag = etag;
+        self
     }
 
     /// Set the additional context.
@@ -215,7 +228,11 @@ pub trait ObjectCopy: DynClone {
     ) -> Result<CopyResult>;
 
     /// Download the object to memory.
-    async fn download(&self, multi_part: Option<MultiPartOptions>) -> Result<CopyContent>;
+    async fn download(
+        &self,
+        multi_part: Option<MultiPartOptions>,
+        state: &CopyState,
+    ) -> Result<CopyContent>;
 
     /// Upload the object to the destination.
     async fn upload(

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -27,6 +27,7 @@ pub struct S3Client {
     inner: Arc<Client>,
     no_get_object_attributes: bool,
     no_checksum_mode: bool,
+    no_precalculated_checksum: bool,
     stalled_stream_protection: StalledStreamProtection,
 }
 
@@ -84,8 +85,15 @@ impl S3Client {
             inner: client,
             no_get_object_attributes,
             no_checksum_mode,
+            no_precalculated_checksum: false,
             stalled_stream_protection,
         }
+    }
+
+    /// Set whether to skip precalculated checksum values on uploads.
+    pub fn with_no_precalculated_checksum(mut self, no_precalculated_checksum: bool) -> Self {
+        self.no_precalculated_checksum = no_precalculated_checksum;
+        self
     }
 
     /// Create a new source S3Client from CLI compatibility and credentials options.
@@ -110,7 +118,8 @@ impl S3Client {
             compatibility.source_no_get_object_attributes(),
             compatibility.source_no_checksum_mode(),
             compatibility.source_stalled_stream_protection(),
-        ))
+        )
+        .with_no_precalculated_checksum(compatibility.source_no_precalculated_checksum()))
     }
 
     /// Create a new destination S3Client from CLI compatibility and credentials options.
@@ -135,7 +144,8 @@ impl S3Client {
             compatibility.destination_no_get_object_attributes(),
             compatibility.destination_no_checksum_mode(),
             compatibility.destination_stalled_stream_protection(),
-        ))
+        )
+        .with_no_precalculated_checksum(compatibility.destination_no_precalculated_checksum()))
     }
 
     /// Whether to avoid `GetObjectAttributes` calls.
@@ -146,6 +156,11 @@ impl S3Client {
     /// Whether to disable checksum mode.
     pub fn no_checksum_mode(&self) -> bool {
         self.no_checksum_mode
+    }
+
+    /// Whether to skip precalculated checksum values on uploads.
+    pub fn no_precalculated_checksum(&self) -> bool {
+        self.no_precalculated_checksum
     }
 
     /// The SSP mode for this client.

--- a/copyrite/src/io/mod.rs
+++ b/copyrite/src/io/mod.rs
@@ -484,6 +484,7 @@ impl SecretsManagerCredentials {
 }
 
 /// Credential overrides from CLI args or environment variables.
+#[derive(PartialEq, Eq)]
 pub struct CredentialOverrides {
     access_key_id: Option<String>,
     secret_access_key: Option<String>,

--- a/copyrite/src/task/copy.rs
+++ b/copyrite/src/task/copy.rs
@@ -663,7 +663,7 @@ impl CopyTask {
             (CopyMode::DownloadUpload, None) => {
                 // `download` attaches a reopen factory, so the upload body is retryable: the SDK
                 // can retry transient failures without buffering the object.
-                let data = self.source_copy.download(None).await?;
+                let data = self.source_copy.download(None, &self.state).await?;
                 let upload = self
                     .destination_copy
                     .upload(data, None, &self.state)
@@ -679,7 +679,7 @@ impl CopyTask {
 
                 self.run_multipart(
                     part_size,
-                    |option, _| async move { source.download(Some(option)).await },
+                    |option, state| async move { source.download(Some(option), &state).await },
                     |data, options, state| async move {
                         destination.upload(data, Some(options), &state).await
                     },
@@ -774,6 +774,7 @@ pub(crate) mod test {
         async fn download(
             &self,
             _multi_part: Option<MultiPartOptions>,
+            _state: &CopyState,
         ) -> error::Result<crate::io::copy::CopyContent> {
             unimplemented!()
         }

--- a/copyrite/src/task/copy.rs
+++ b/copyrite/src/task/copy.rs
@@ -3,7 +3,7 @@
 
 use crate::checksum::Ctx;
 use crate::checksum::aws_etag::PREFERRED_PART_SIZES;
-use crate::checksum::file::SumsFile;
+use crate::checksum::file::{Checksum, SumsFile};
 use crate::cli::{CopyMode, MetadataCopy};
 use crate::error::Error::CopyError;
 use crate::error::{ApiError, Error, Result};
@@ -44,6 +44,7 @@ pub struct CopyTaskBuilder {
 pub struct CopySettings {
     part_size: Option<u64>,
     ctx: Ctx,
+    sum: Option<String>,
     object_size: u64,
 }
 
@@ -61,13 +62,20 @@ impl CopySettings {
         Self {
             part_size,
             ctx,
+            sum: None,
             object_size,
         }
     }
 
+    /// Set the known value of the additional checksum from the source sums file.
+    pub fn with_sum(mut self, sum: Option<String>) -> Self {
+        self.sum = sum;
+        self
+    }
+
     /// Get the inner values.
-    pub fn into_inner(self) -> (Option<u64>, Ctx, u64) {
-        (self.part_size, self.ctx, self.object_size)
+    pub fn into_inner(self) -> (Option<u64>, Ctx, Option<String>, u64) {
+        (self.part_size, self.ctx, self.sum, self.object_size)
     }
 }
 
@@ -203,7 +211,8 @@ impl CopyTaskBuilder {
                 )
             });
         if let Some((part_size, ctx)) = ctx {
-            return Ok(CopySettings::new(Some(part_size), ctx, info.size));
+            let sum = sums.checksums.get(&ctx).cloned().map(Checksum::into_inner);
+            return Ok(CopySettings::new(Some(part_size), ctx, info.size).with_sum(sum));
         }
 
         // Otherwise, check if a preferred single part checksum exists.
@@ -213,25 +222,27 @@ impl CopyTaskBuilder {
             .find(|ctx| ctx.is_preferred_single_part(&destination))
             .take_if(|_| Self::is_single_part(info.size, info.max_part_size));
         if let Some(ctx) = ctx {
-            return Ok(CopySettings::new(None, ctx.clone(), info.size));
+            let sum = sums.checksums.get(ctx).cloned().map(Checksum::into_inner);
+            return Ok(CopySettings::new(None, ctx.clone(), info.size).with_sum(sum));
         }
 
         // If none of the above apply, fall back based on the object size, keeping the best
         // available checksum as the additional context to set on the copy.
-        let additional_ctx = sums.checksums.keys().next().cloned().unwrap_or_default();
+        let (additional_ctx, sum) = sums
+            .checksums
+            .iter()
+            .next()
+            .map(|(ctx, sum)| (ctx.clone(), Some(sum.clone().into_inner())))
+            .unwrap_or_default();
         if Self::is_single_part(info.size, info.max_part_size) {
-            Ok(CopySettings::new(None, additional_ctx, info.size))
+            Ok(CopySettings::new(None, additional_ctx, info.size).with_sum(sum))
         } else if let Some(part_size) = Self::preferred_multipart_part_size(
             info.size,
             info.max_parts,
             info.max_part_size,
             info.min_part_size,
         ) {
-            Ok(CopySettings::new(
-                Some(part_size),
-                additional_ctx,
-                info.size,
-            ))
+            Ok(CopySettings::new(Some(part_size), additional_ctx, info.size).with_sum(sum))
         } else {
             Err(CopyError(format!(
                 "failed to find a valid part size for object size `{}`",
@@ -310,8 +321,11 @@ impl CopyTaskBuilder {
         };
 
         // Use the additional sum from the settings if available or the default.
-        let additional_ctx = settings
-            .map(|settings| settings.into_inner().1)
+        let (additional_ctx, additional_sum) = settings
+            .map(|settings| {
+                let (_, ctx, sum, _) = settings.into_inner();
+                (ctx, sum)
+            })
             .unwrap_or_default();
 
         let threshold = self
@@ -325,7 +339,8 @@ impl CopyTaskBuilder {
             return if Self::is_multipart(size, part_size, max_parts, max_part_size, min_part_size) {
                 Ok((
                     self,
-                    CopySettings::new(Some(part_size), additional_ctx, size),
+                    CopySettings::new(Some(part_size), additional_ctx, size)
+                        .with_sum(additional_sum),
                 ))
             } else {
                 Err(CopyError(format!(
@@ -348,7 +363,8 @@ impl CopyTaskBuilder {
             {
                 Ok((
                     self,
-                    CopySettings::new(Some(part_size), additional_ctx, size),
+                    CopySettings::new(Some(part_size), additional_ctx, size)
+                        .with_sum(additional_sum),
                 ))
             } else {
                 Err(err_fn())
@@ -357,7 +373,10 @@ impl CopyTaskBuilder {
 
         // Otherwise use single part if possible.
         if Self::is_single_part(size, max_part_size) {
-            return Ok((self, CopySettings::new(None, additional_ctx, size)));
+            return Ok((
+                self,
+                CopySettings::new(None, additional_ctx, size).with_sum(additional_sum),
+            ));
         }
 
         // This condition may occur if the size is greater than the possible single part upload
@@ -455,6 +474,7 @@ impl CopyTaskBuilder {
 
         let copy_task = CopyTask {
             additional_sums: settings.ctx,
+            additional_sum: settings.sum,
             part_size: settings.part_size,
             source,
             source_copy,
@@ -505,6 +525,7 @@ pub type CopyTaskResult = result::Result<CopyTask, CopyTaskError>;
 /// Execute the copy task.
 pub struct CopyTask {
     additional_sums: Ctx,
+    additional_sum: Option<String>,
     part_size: Option<u64>,
     source: Provider,
     destination: Provider,
@@ -642,6 +663,7 @@ impl CopyTask {
 
     async fn do_copy(&mut self) -> Result<()> {
         self.state.set_additional_ctx(self.additional_sums.clone());
+        self.state.set_additional_sum(self.additional_sum.clone());
 
         match (self.copy_mode, self.part_size) {
             (CopyMode::ServerSide, None) => {
@@ -892,6 +914,7 @@ pub(crate) mod test {
 
         let mut task = CopyTask {
             additional_sums: Ctx::default(),
+            additional_sum: None,
             part_size: Some(part_size),
             source: Provider::try_from("s3://bucket/source").unwrap(),
             destination: Provider::try_from("s3://bucket/destination").unwrap(),


### PR DESCRIPTION
Closes #115 

### Changes
* This fixes the underlying issue which was causing copies to fail. The stream no longer opens unnecessary connections, and only does so when it actually needs to send bytes.
    * When a copy would fail for this reason it would result in errors like:
        * `Your socket connection to the server was not read from or written to within the timeout period. Idle connections will be closed."`

### Other changes
* Also adding a few other improvements:
    * Make a distinction between precalculated checksums and automatically calculated checksums. The SDK can automatically calculate some checksums, but not others. This fixes as issue that could have caused an error if the precalculated checksums were attempted to be automatically derived.
        * This also sets the object ETag to fetch via `If-Match`, which is required to ensure that the correct object is being fetched.
    * Add an option to disable this as compatibility, as Ceph doesn't necessarily support this.
    * Expand the cases where server-side copies can be used.
        * This is implemented as a head-object check. Now it's possible to use server-side copies within Ceph and for cross-account on AWS. 